### PR TITLE
Added Strain exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,8 @@
     "allergies",
     "anagram",
     "clock",
-    "series"
+    "series",
+    "strain"
   ],
   "deprecated": [
 

--- a/strain/Example.fs
+++ b/strain/Example.fs
@@ -1,0 +1,5 @@
+﻿module Seq
+
+    let keep pred xs = seq { for x in xs do if pred x then yield x }
+
+    let discard pred = keep (not << pred)

--- a/strain/Strain.fs
+++ b/strain/Strain.fs
@@ -1,0 +1,5 @@
+﻿module Seq
+
+    let keep pred xs = ???
+
+    let discard pred xs = ???

--- a/strain/StrainTests.fs
+++ b/strain/StrainTests.fs
@@ -1,0 +1,87 @@
+module StrainTests
+
+open System.Collections.Specialized
+open NUnit.Framework
+
+[<TestFixture>]
+type StrainTests() =
+    [<Test>]
+    member tests.Empty_keep() =
+        Assert.That([] |> Seq.keep (fun x -> x < 10), Is.EqualTo([]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Keep_everything() =
+        Assert.That(set [1; 2; 3] |> Seq.keep (fun x -> x < 10), Is.EqualTo(set [1; 2; 3]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Keep_first_and_last() =
+        Assert.That([|1; 2; 3|] |> Seq.keep (fun x -> x % 2 <> 0), Is.EqualTo([|1; 3|]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Keep_neither_first_nor_last() =
+        Assert.That([1; 2; 3; 4; 5] |> Seq.keep (fun x -> x % 2 = 0), Is.EqualTo([2; 4]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Keep_strings() =
+        let words = "apple zebra banana zombies cherimoya zelot".Split(' ');
+        Assert.That(words |> Seq.keep (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("zebra zombies zelot".Split(' ')))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Keep_arrays() =
+        let actual = [|
+                        [|1; 2; 3|];
+                        [|5; 5; 5|];
+                        [|5; 1; 2|];
+                        [|2; 1; 2|];
+                        [|1; 5; 2|];
+                        [|2; 2; 1|];
+                        [|1; 2; 5|]
+                     |]
+        let expected = [| [|5; 5; 5|]; [|5; 1; 2|]; [|1; 5; 2|]; [|1; 2; 5|] |]
+        Assert.That(actual |> Seq.keep (Array.exists ((=) 5)), Is.EqualTo(expected))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Empty_discard() =
+        Assert.That([] |> Seq.discard (fun x -> x < 10), Is.EqualTo([]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Discard_nothing() =
+        Assert.That(set [1; 2; 3] |> Seq.discard (fun x -> x > 10), Is.EqualTo(set [1; 2; 3]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Discard_first_and_last() =
+        Assert.That([|1; 2; 3|] |> Seq.discard (fun x -> x % 2 <> 0), Is.EqualTo([|2|]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Discard_neither_first_nor_last() =
+        Assert.That([1; 2; 3; 4; 5] |> Seq.discard (fun x -> x % 2 = 0), Is.EqualTo([1; 3; 5]))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Discard_strings() =
+        let words = "apple zebra banana zombies cherimoya zelot".Split(' ')
+        Assert.That(words |> Seq.discard (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("apple banana cherimoya".Split(' ')))
+
+    [<Test>]
+    [<Ignore>]
+    member tests.Discard_arrays() =
+        let actual = [|
+                        [|1; 2; 3|];
+                        [|5; 5; 5|];
+                        [|5; 1; 2|];
+                        [|2; 1; 2|];
+                        [|1; 5; 2|];
+                        [|2; 2; 1|];
+                        [|1; 2; 5|]
+                     |]
+        let expected = [| [|1; 2; 3|]; [|2; 1; 2|]; [|2; 2; 1|] |]
+        Assert.That(actual |> Seq.discard (Array.exists ((=) 5)), Is.EqualTo(expected))


### PR DESCRIPTION
This PR implements the Strain exercise. In C#, the exercise is meant to work for all sequences and one is expected to write an extension method. However, I thought it would be nice for people to know that they can very easily extend the `Seq` module and thus add the new `keep` and `discard` methods into that module. 

However, as people may be unaware on how to do that, I have followed the approach taken in some Haskell exercises where a basic implementation file is automatically provided, to help the user use the correct structure for the code. An example of this can be found here: https://github.com/exercism/xhaskell/tree/master/zipper Is this something you are all comfortable with? Should I give make the basic implementation file compile, or not (I have opted for the latter)?