### PR TITLE
Remove testfixture

### DIFF
--- a/exercises/accumulate/AccumulateTests.fs
+++ b/exercises/accumulate/AccumulateTests.fs
@@ -4,7 +4,6 @@ open System
 open NUnit.Framework
 open Accumulate
 
-[<TestFixture>]
 type AccumulateTests() =
 
     let accum = Accumulate()

--- a/exercises/acronym/AcronymTests.fs
+++ b/exercises/acronym/AcronymTests.fs
@@ -3,7 +3,6 @@ module AcronymTests
 open NUnit.Framework
 open Acronym
 
-[<TestFixture>]
 type AcronymTests() =
 
     [<Test>]

--- a/exercises/allergies/AllergiesTests.fs
+++ b/exercises/allergies/AllergiesTests.fs
@@ -4,7 +4,6 @@ open System
 open NUnit.Framework
 open Allergies
 
-[<TestFixture>]
 type AllergiesTests() =
 
     [<Test>]

--- a/exercises/anagram/AnagramTests.fs
+++ b/exercises/anagram/AnagramTests.fs
@@ -4,7 +4,6 @@ open System
 open NUnit.Framework
 open Anagram
 
-[<TestFixture>]
 type AnagramTests() =
     [<Test>]
     member tests.No_matches() =

--- a/exercises/atbash-cipher/AtbashTests.fs
+++ b/exercises/atbash-cipher/AtbashTests.fs
@@ -3,7 +3,6 @@ module AtbastTests
 open NUnit.Framework
 open Atbash
 
-[<TestFixture>]
 type AtbashTests() =
     [<TestCase("no", ExpectedResult = "ml")>]
     [<TestCase("yes", ExpectedResult = "bvh", Ignore = true)>]

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open BankAccount
 
-[<TestFixture>]
 type BankAccountTest() =
     let account = BankAccount()
 

--- a/exercises/beer-song/BeerSongTest.fs
+++ b/exercises/beer-song/BeerSongTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open BeerSong
 
-[<TestFixture>]
 type BeerSongTest() = 
     let beersong = BeerSong()
 

--- a/exercises/binary/BinaryTests.fs
+++ b/exercises/binary/BinaryTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Binary
 
-[<TestFixture>]
 type BinaryTests() =
     
     [<TestCase("1", ExpectedResult = 1)>]

--- a/exercises/bob/BobTest.fs
+++ b/exercises/bob/BobTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Bob
 
-[<TestFixture>]
 type BobTest() =
     
     [<Test>]

--- a/exercises/clock/ClockTests.fs
+++ b/exercises/clock/ClockTests.fs
@@ -4,7 +4,6 @@ open System
 open NUnit.Framework
 open Clock
 
-[<TestFixture>]
 type ClockTests() =
     [<TestCase(8, "08:00")>]
     [<TestCase(9, "09:00", Ignore = true)>]

--- a/exercises/crypto-square/CryptoSquareTests.fs
+++ b/exercises/crypto-square/CryptoSquareTests.fs
@@ -3,7 +3,6 @@ module CryptoSquareTests
 open NUnit.Framework
 open CryptoSquare
 
-[<TestFixture>]
 type CryptoSquareTests() =
 
     [<Test>]

--- a/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open DifferenceOfSquares
 
-[<TestFixture>]
 type DifferenceOfSquaresTests() =
     
     [<Test>]

--- a/exercises/etl/ETLTests.fs
+++ b/exercises/etl/ETLTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open ETL
 
-[<TestFixture>]
 type ETLTests() =
 
     [<Test>]

--- a/exercises/gigasecond/GigasecondTest.fs
+++ b/exercises/gigasecond/GigasecondTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Gigasecond
 
-[<TestFixture>]
 type GigasecondTest() =
     
     [<Test>]

--- a/exercises/grade-school/GradeSchoolTests.fs
+++ b/exercises/grade-school/GradeSchoolTests.fs
@@ -3,7 +3,6 @@ module GradeSchoolTests
 open NUnit.Framework
 open School
 
-[<TestFixture>]
 type GradeSchoolTests() = 
     [<Test>]
     member tests.New_school_has_an_empty_roster() =

--- a/exercises/grains/GrainsTest.fs
+++ b/exercises/grains/GrainsTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Grains
 
-[<TestFixture>]
 type GrainsTest() =
     let grains = Grains()
 

--- a/exercises/hamming/HammingTests.fs
+++ b/exercises/hamming/HammingTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Hamming
 
-[<TestFixture>]
 type HammingTests() =
 
     [<Test>]

--- a/exercises/leap/LeapYearTests.fs
+++ b/exercises/leap/LeapYearTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open LeapYear
 
-[<TestFixture>]
 type LeapYearTests() =
 
     [<Test>]

--- a/exercises/linked-list/LinkedListTests.fs
+++ b/exercises/linked-list/LinkedListTests.fs
@@ -3,7 +3,6 @@ module DequeTests
 open NUnit.Framework
 open Deque
 
-[<TestFixture>]
 type DequeTests() =
 
     [<Test>]

--- a/exercises/luhn/LuhnTests.fs
+++ b/exercises/luhn/LuhnTests.fs
@@ -3,7 +3,6 @@ module LuhnTests
 open NUnit.Framework
 open Luhn
 
-[<TestFixture>]
 type LuhnTests() =    
     [<Test>]
     member tests.Check_digit_is_the_rightmost_digit() =

--- a/exercises/octal/OctalTests.fs
+++ b/exercises/octal/OctalTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Octal
 
-[<TestFixture>]
 type OctalTests() =
     
     [<TestCase("1", ExpectedResult = 1)>]

--- a/exercises/pig-latin/PigLatinTests.fs
+++ b/exercises/pig-latin/PigLatinTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open PigLatin
 
-[<TestFixture>]
 type PigLatinTests() =
     
     [<TestCase("apple", ExpectedResult = "appleay")>]

--- a/exercises/raindrops/RaindropsTests.fs
+++ b/exercises/raindrops/RaindropsTests.fs
@@ -3,7 +3,6 @@ module RaindropsTests
 open NUnit.Framework
 open Raindrops
 
-[<TestFixture>]
 type RaindropsTests() =
     [<TestCase(1, ExpectedResult = "1")>]
     [<TestCase(52, ExpectedResult = "52", Ignore = true)>]

--- a/exercises/rna-transcription/RNATranscriptionTests.fs
+++ b/exercises/rna-transcription/RNATranscriptionTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Complement
 
-[<TestFixture>]
 type RNATranscriptionTest() =
     
     [<Test>]

--- a/exercises/robot-name/RobotNameTest.fs
+++ b/exercises/robot-name/RobotNameTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open RobotName
 
-[<TestFixture>]
 type RobotNameTest() =
     let robot = RobotName()
 

--- a/exercises/roman-numerals/RomanNumeralTests.fs
+++ b/exercises/roman-numerals/RomanNumeralTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open RomanNumeral
 
-[<TestFixture>]
 type RomanNumeralTests() =
     
     [<TestCase(0, ExpectedResult = "")>]

--- a/exercises/scrabble-score/ScrabbleScoreTests.fs
+++ b/exercises/scrabble-score/ScrabbleScoreTests.fs
@@ -3,7 +3,6 @@ module ScrabbleScoreTests
 open NUnit.Framework
 open Scrabble
 
-[<TestFixture>]
 type ScrabbleScoreTest() = 
   
     [<Test>]

--- a/exercises/series/SeriesTests.fs
+++ b/exercises/series/SeriesTests.fs
@@ -4,7 +4,6 @@ open System
 open NUnit.Framework
 open Series
 
-[<TestFixture>]
 type SeriesTests() =
     static member SliceOneTestData = 
         [| 

--- a/exercises/space-age/SpaceAgeTest.fs
+++ b/exercises/space-age/SpaceAgeTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open SpaceAge
 
-[<TestFixture>]
 type SpaceAgeTest() =
     
     [<Test>]

--- a/exercises/strain/StrainTests.fs
+++ b/exercises/strain/StrainTests.fs
@@ -3,7 +3,6 @@ module StrainTests
 open System.Collections.Specialized
 open NUnit.Framework
 
-[<TestFixture>]
 type StrainTests() =
     [<Test>]
     member tests.Empty_keep() =

--- a/exercises/sum-of-multiples/SumOfMultiplesTest.fs
+++ b/exercises/sum-of-multiples/SumOfMultiplesTest.fs
@@ -3,7 +3,6 @@ module SumOfMultiplesTest
 open NUnit.Framework
 open SumOfMultiples
 
-[<TestFixture>]
 type SumOfMultiplesTest() =
     [<Test>]
     member tc.Sum_to_1() =

--- a/exercises/triangle/TriangleTest.fs
+++ b/exercises/triangle/TriangleTest.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Triangle
 
-[<TestFixture>]
 type TriangleTest() =
 
     [<Test>]

--- a/exercises/trinary/TrinaryTests.fs
+++ b/exercises/trinary/TrinaryTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Trinary
 
-[<TestFixture>]
 type TrinaryTests() =
     
     [<TestCase("1", ExpectedResult = 1)>]

--- a/exercises/word-count/WordCountTests.fs
+++ b/exercises/word-count/WordCountTests.fs
@@ -3,7 +3,6 @@
 open NUnit.Framework
 open Phrase
 
-[<TestFixture>]
 type WordCountTests() =
     
     [<Test>]


### PR DESCRIPTION
As we're now using NUnit 3, the `[<TestFixture>]` attribute is no longer necessary.