### PR TITLE
Convert existing exercises to idiomatic F#. Closes #59

### DIFF
--- a/exercises/accumulate/AccumulateTests.fs
+++ b/exercises/accumulate/AccumulateTests.fs
@@ -4,39 +4,36 @@ open System
 open NUnit.Framework
 open Accumulate
 
-type AccumulateTests() =
+let reverse (str:string) = new string(str.ToCharArray() |> Array.rev)
 
-    let accum = Accumulate()
-    let reverse (str:string) = new string(str.ToCharArray() |> Array.rev)
+[<Test>]
+let ``Empty accumulation produces empty accumulation`` () =
+    Assert.That(accumulate (fun x -> x + 1) List.empty, Is.EqualTo(List.empty))
 
-    [<Test>]
-    member tests.Empty_accumulation_produces_empty_accumulation() =
-        Assert.That(accum.accumulate((fun x -> x + 1), List.empty), Is.EqualTo(List.empty))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Identity accumulation returns unmodified list`` () =
+    Assert.That(accumulate id [1; 2; 3], Is.EqualTo([1; 2; 3]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Identity_accumulation_returns_unmodified_list() =
-        Assert.That(accum.accumulate(id, [1; 2; 3]), Is.EqualTo([1; 2; 3]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Accumulate squares`` () =
+    Assert.That(accumulate (fun x -> x * x) [1; 2; 3], Is.EqualTo([1; 4; 9]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Accumulate_squares() =
-        Assert.That(accum.accumulate((fun x -> x * x), [1; 2; 3]), Is.EqualTo([1; 4; 9]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Accumulate upcases`` () =
+    Assert.That(accumulate (fun (x:string) -> x.ToUpper()) ["hello"; "world"],
+        Is.EqualTo(["HELLO"; "WORLD"]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Accumulate_upcases() =
-        Assert.That(accum.accumulate((fun (x:string) -> x.ToUpper()), ["hello"; "world"]),
-            Is.EqualTo(["HELLO"; "WORLD"]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Accumulate reversed strings`` () =
+    Assert.That(accumulate reverse (List.ofArray ("the quick brown fox etc".Split(' '))),
+        Is.EqualTo(List.ofArray ("eht kciuq nworb xof cte".Split(' '))))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Accumulate_reversed_strings() =
-        Assert.That(accum.accumulate(reverse, List.ofArray ("the quick brown fox etc".Split(' '))),
-            Is.EqualTo(List.ofArray ("eht kciuq nworb xof cte".Split(' '))))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Accumulate_within_accumulate() =
-        Assert.That(accum.accumulate((fun (x:string) -> String.Join(" ", accum.accumulate((fun y -> x + y), ["1"; "2"; "3"]))), ["a"; "b"; "c"]),
-            Is.EqualTo(["a1 a2 a3"; "b1 b2 b3"; "c1 c2 c3"]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Accumulate within accumulate`` () =
+    Assert.That(accumulate (fun (x:string) -> String.Join(" ", accumulate (fun y -> x + y) ["1"; "2"; "3"])) ["a"; "b"; "c"],
+        Is.EqualTo(["a1 a2 a3"; "b1 b2 b3"; "c1 c2 c3"]))

--- a/exercises/accumulate/Example.fs
+++ b/exercises/accumulate/Example.fs
@@ -1,11 +1,8 @@
 ﻿module Accumulate
 
-type Accumulate() =
+let rec accumulateLoop func input acc = 
+    match input with
+        | [] -> acc |> List.rev
+        | x::xs -> accumulateLoop func xs (func x :: acc)
 
-    let rec accumulateLoop func input acc = 
-        match input with
-            | [] -> acc |> List.rev
-            | x::xs -> accumulateLoop func xs (func x :: acc)
-
-    member this.accumulate(func, input) = accumulateLoop func input List.empty
-
+let accumulate func input = accumulateLoop func input List.empty

--- a/exercises/acronym/AcronymTests.fs
+++ b/exercises/acronym/AcronymTests.fs
@@ -3,17 +3,15 @@ module AcronymTests
 open NUnit.Framework
 open Acronym
 
-type AcronymTests() =
-
-    [<Test>]
-    member tests.Empty_string_abbreviated_to_empty_string() =
-        Assert.That(Acronym().abbreviate(""), Is.EqualTo(""))
+[<Test>]
+let ``Empty string abbreviated to empty string`` () =
+    Assert.That(acronym "", Is.EqualTo(""))
         
-    [<TestCase("Portable Network Graphics", ExpectedResult = "PNG", Ignore = "Remove to run test case")>]
-    [<TestCase("Ruby on Rails", ExpectedResult = "ROR", Ignore = "Remove to run test case")>]
-    [<TestCase("HyperText Markup Language", ExpectedResult = "HTML", Ignore = "Remove to run test case")>]
-    [<TestCase("First In, First Out", ExpectedResult = "FIFO", Ignore = "Remove to run test case")>]
-    [<TestCase("PHP: Hypertext Preprocessor", ExpectedResult = "PHP", Ignore = "Remove to run test case")>]
-    [<TestCase("Complementary metal-oxide semiconductor", ExpectedResult = "CMOS", Ignore = "Remove to run test case")>]
-    member tests.Phrase_abbreviated_to_acronym(phrase) =
-        Acronym().abbreviate(phrase)
+[<TestCase("Portable Network Graphics", ExpectedResult = "PNG", Ignore = "Remove to run test case")>]
+[<TestCase("Ruby on Rails", ExpectedResult = "ROR", Ignore = "Remove to run test case")>]
+[<TestCase("HyperText Markup Language", ExpectedResult = "HTML", Ignore = "Remove to run test case")>]
+[<TestCase("First In, First Out", ExpectedResult = "FIFO", Ignore = "Remove to run test case")>]
+[<TestCase("PHP: Hypertext Preprocessor", ExpectedResult = "PHP", Ignore = "Remove to run test case")>]
+[<TestCase("Complementary metal-oxide semiconductor", ExpectedResult = "CMOS", Ignore = "Remove to run test case")>]
+let ``Phrase abbreviated to acronym`` (phrase: string) =
+    acronym phrase

--- a/exercises/acronym/Example.fs
+++ b/exercises/acronym/Example.fs
@@ -3,9 +3,8 @@
 open System
 open System.Text.RegularExpressions
 
-type Acronym() =
-    member this.abbreviate(phrase:string) =  
-        let acronymChar = Char.ToUpperInvariant << Seq.head
-        let words = Regex.Matches(phrase, "[A-Z]+[a-z]*|[a-z]+")
-        let chars = [|for word in words do yield word.Value |> acronymChar|]        
-        new String(chars)
+let acronym (phrase:string) =  
+    let acronymChar = Char.ToUpperInvariant << Seq.head
+    let words = Regex.Matches(phrase, "[A-Z]+[a-z]*|[a-z]+")
+    let chars = [|for word in words do yield word.Value |> acronymChar|]        
+    new String(chars)

--- a/exercises/allergies/AllergiesTests.fs
+++ b/exercises/allergies/AllergiesTests.fs
@@ -4,83 +4,71 @@ open System
 open NUnit.Framework
 open Allergies
 
-type AllergiesTests() =
+[<Test>]
+let ``No allergies means not allergic`` () =
+    Assert.That(allergicTo Allergen.Peanuts 0, Is.False)
+    Assert.That(allergicTo Allergen.Cats 0, Is.False)
+    Assert.That(allergicTo Allergen.Strawberries 0, Is.False)
 
-    [<Test>]
-    member tests.No_allergies_means_not_allergic() =
-        let allergies = Allergies(0);
-        Assert.That(allergies.allergicTo(Allergen.Peanuts), Is.False);
-        Assert.That(allergies.allergicTo(Allergen.Cats), Is.False);
-        Assert.That(allergies.allergicTo(Allergen.Strawberries), Is.False)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to eggs`` () =
+    Assert.That(allergicTo Allergen.Eggs 1, Is.True)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_eggs() =
-        let allergies = Allergies(1);
-        Assert.That(allergies.allergicTo(Allergen.Eggs), Is.True)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to eggs in addition to other stuff`` () =
+    Assert.That(allergicTo Allergen.Eggs 5, Is.True)
+    Assert.That(allergicTo Allergen.Shellfish 5, Is.True)
+    Assert.That(allergicTo Allergen.Strawberries 5, Is.False)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_eggs_in_addition_to_other_stuff() =
-        let allergies = Allergies(5);
-        Assert.That(allergies.allergicTo(Allergen.Eggs), Is.True);
-        Assert.That(allergies.allergicTo(Allergen.Shellfish), Is.True);
-        Assert.That(allergies.allergicTo(Allergen.Strawberries), Is.False)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``No allergies at all`` () =
+    Assert.That(allergies 0, Is.Empty)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.No_allergies_at_all() =
-        let allergies = Allergies(0);
-        Assert.That(allergies.list(), Is.Empty)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to just eggs`` () =
+    Assert.That(allergies 1, Is.EqualTo([Allergen.Eggs]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_just_eggs() =
-        let allergies = Allergies(1);
-        Assert.That(allergies.list(), Is.EqualTo([Allergen.Eggs]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to just peanuts`` () =
+    Assert.That(allergies 2, Is.EqualTo([Allergen.Peanuts]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_just_peanuts() =
-        let allergies = Allergies(2);
-        Assert.That(allergies.list(), Is.EqualTo([Allergen.Peanuts]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to eggs and peanuts`` () =
+    Assert.That(allergies 3, Is.EqualTo([Allergen.Eggs; Allergen.Peanuts]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_eggs_and_peanuts() =
-        let allergies = Allergies(3);
-        Assert.That(allergies.list(), Is.EqualTo([Allergen.Eggs; Allergen.Peanuts]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to lots of stuff`` () =
+    Assert.That(allergies 248,
+        Is.EqualTo([Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_lots_of_stuff() =
-        let allergies = Allergies(248);
-        Assert.That(allergies.list(),
-            Is.EqualTo([Allergen.Strawberries; Allergen.Tomatoes; Allergen.Chocolate; Allergen.Pollen; Allergen.Cats]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Allergic to everything`` () =
+    Assert.That(allergies 255,
+        Is.EqualTo([Allergen.Eggs;
+                    Allergen.Peanuts;
+                    Allergen.Shellfish;
+                    Allergen.Strawberries;
+                    Allergen.Tomatoes;
+                    Allergen.Chocolate;
+                    Allergen.Pollen;
+                    Allergen.Cats]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Allergic_to_everything() =
-        let allergies = Allergies(255);
-        Assert.That(allergies.list(),
-            Is.EqualTo([Allergen.Eggs;
-                        Allergen.Peanuts;
-                        Allergen.Shellfish;
-                        Allergen.Strawberries;
-                        Allergen.Tomatoes;
-                        Allergen.Chocolate;
-                        Allergen.Pollen;
-                        Allergen.Cats]))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Ignore_non_allergen_score_parts() =
-        let allergies = Allergies(509);
-        Assert.That(allergies.list(),
-            Is.EqualTo([Allergen.Eggs;
-                        Allergen.Shellfish;
-                        Allergen.Strawberries;
-                        Allergen.Tomatoes;
-                        Allergen.Chocolate;
-                        Allergen.Pollen;
-                        Allergen.Cats]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Ignore non allergen score parts`` () =
+    Assert.That(allergies 509,
+        Is.EqualTo([Allergen.Eggs;
+                    Allergen.Shellfish;
+                    Allergen.Strawberries;
+                    Allergen.Tomatoes;
+                    Allergen.Chocolate;
+                    Allergen.Pollen;
+                    Allergen.Cats]))

--- a/exercises/allergies/Example.fs
+++ b/exercises/allergies/Example.fs
@@ -12,11 +12,10 @@ type Allergen =
    | Pollen = 64
    | Cats = 128
 
-type Allergies(codedAllergies) =
+let allergicTo (allergen: Allergen) (codedAllergies: int) = codedAllergies &&& int allergen <> 0
 
-    member this.allergicTo(allergen: Allergen) = codedAllergies &&& int allergen <> 0
-
-    member this.list() = Enum.GetValues(typeof<Allergen>) 
-                         |> Seq.cast<Allergen> 
-                         |> List.ofSeq 
-                         |> List.filter this.allergicTo
+let allergies (codedAllergies: int) = 
+    Enum.GetValues(typeof<Allergen>) 
+    |> Seq.cast<Allergen> 
+    |> List.ofSeq 
+    |> List.filter (fun allergen -> allergicTo allergen codedAllergies)

--- a/exercises/anagram/AnagramTests.fs
+++ b/exercises/anagram/AnagramTests.fs
@@ -4,75 +4,65 @@ open System
 open NUnit.Framework
 open Anagram
 
-type AnagramTests() =
-    [<Test>]
-    member tests.No_matches() =
-        let detector = new Anagram("diaper")
-        let words = ["hello"; "world"; "zombies"; "pants"]
-        let results = []
-        Assert.That(detector.Match(words), Is.EquivalentTo(results))
+[<Test>]
+let ``No matches`` () =
+    let words = ["hello"; "world"; "zombies"; "pants"]
+    let expected = []
+    Assert.That(anagrams words "diaper", Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Detect_simple_anagram() =
-        let detector = new Anagram("ant")
-        let words = ["tan"; "stand"; "at"]
-        let results = ["tan"]
-        Assert.That(detector.Match(words), Is.EquivalentTo(results))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Detect simple anagram`` () =
+    let words = ["tan"; "stand"; "at"]
+    let expected = ["tan"]
+    Assert.That(anagrams words "ant", Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Detect_multiple_anagrams() =
-        let detector = new Anagram("master");
-        let words = ["stream"; "pigeon"; "maters"];
-        let results = ["maters"; "stream"];
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Detect multiple anagrams`` () =
+    let words = ["stream"; "pigeon"; "maters"]
+    let expected = ["maters"; "stream"]
+    Assert.That(anagrams words "master", Is.EquivalentTo(expected));
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Does_not_confuse_different_duplicates() =
-        let detector = new Anagram("galea");
-        let words = ["eagle"];
-        let results = []
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Does not confuse different duplicates`` () =
+    let words = ["eagle"]
+    let expected = []
+    Assert.That(anagrams words "galea", Is.EquivalentTo(expected));
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Identical_word_is_not_anagram() =
-        let detector = new Anagram("corn");
-        let words = ["corn"; "dark"; "Corn"; "rank"; "CORN"; "cron"; "park"];
-        let results = ["cron"];
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Identical word is not anagram`` () =
+    let words = ["corn"; "dark"; "Corn"; "rank"; "CORN"; "cron"; "park"]
+    let expected = ["cron"]
+    Assert.That(anagrams words "corn", Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Eliminate_anagrams_with_same_checksum() =
-        let detector = new Anagram("mass");
-        let words = ["last"];
-        let results = []
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Eliminate anagrams with same checksum`` () =
+    let words = ["last"]
+    let expected = []
+    Assert.That(anagrams words "mass", Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Eliminate_anagram_subsets() =
-        let detector = new Anagram("good");
-        let words = ["dog"; "goody"];
-        let results = []
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Eliminate anagram subsets`` () =
+    let words = ["dog"; "goody"]
+    let expected = []
+    Assert.That(anagrams words "good", Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Detect_anagrams() =
-        let detector = new Anagram("allergy");
-        let words = ["gallery"; "ballerina"; "regally"; "clergy"; "largely"; "leading"];
-        let results = ["gallery"; "largely"; "regally"];
-        let enumerable = detector.Match(words);
-        Assert.That(enumerable, Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Detect anagrams`` () =
+    let words = ["gallery"; "ballerina"; "regally"; "clergy"; "largely"; "leading"]
+    let expected = ["gallery"; "largely"; "regally"]
+    let actual = anagrams words "allergy"
+    Assert.That(actual, Is.EquivalentTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Anagrams_are_case_insensitive() =
-        let detector = new Anagram("Orchestra");
-        let words = ["cashregister"; "Carthorse"; "radishes"];
-        let results = ["Carthorse"];
-        Assert.That(detector.Match(words), Is.EquivalentTo(results));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Anagrams are case insensitive`` () =
+    let words = ["cashregister"; "Carthorse"; "radishes"]
+    let expected = ["Carthorse"]
+    Assert.That(anagrams words "Orchestra", Is.EquivalentTo(expected))

--- a/exercises/anagram/Example.fs
+++ b/exercises/anagram/Example.fs
@@ -2,12 +2,11 @@
 
 open System
 
-type Anagram(target) =   
-
-    let normalize (str:string) = new string(str.ToLowerInvariant().ToCharArray() |> Array.sort)
+let normalize (str:string) = new string(str.ToLowerInvariant().ToCharArray() |> Array.sort)    
+let unequal str other = not (String.Equals(str, other, StringComparison.InvariantCultureIgnoreCase))
+       
+let anagrams sources target = 
     let normalizedTarget = normalize target
-    let unequal str = not (String.Equals(str, target, StringComparison.InvariantCultureIgnoreCase))
+    let isMatch str = normalize str = normalizedTarget && unequal str target
     
-    let isMatch str = normalize str = normalizedTarget && unequal str
-
-    member this.Match sources = List.filter isMatch sources
+    List.filter isMatch sources

--- a/exercises/atbash-cipher/AtbashTests.fs
+++ b/exercises/atbash-cipher/AtbashTests.fs
@@ -1,15 +1,14 @@
-module AtbastTests
+module AtbashTests
 
 open NUnit.Framework
 open Atbash
 
-type AtbashTests() =
-    [<TestCase("no", ExpectedResult = "ml")>]
-    [<TestCase("yes", ExpectedResult = "bvh", Ignore = "Remove to run test case")>]
-    [<TestCase("OMG", ExpectedResult = "lnt", Ignore = "Remove to run test case")>]
-    [<TestCase("mindblowingly", ExpectedResult = "nrmwy oldrm tob", Ignore = "Remove to run test case")>]
-    [<TestCase("Testing, 1 2 3, testing.", ExpectedResult = "gvhgr mt123 gvhgr mt", Ignore = "Remove to run test case")>]
-    [<TestCase("Truth is fiction.", ExpectedResult = "gifgs rhurx grlm", Ignore = "Remove to run test case")>]
-    [<TestCase("The quick brown fox jumps over the lazy dog.", ExpectedResult = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt", Ignore = "Remove to run test case")>]
-    member tests.Encodes_words_using_atbash_cipher(words) =        
-        Atbash().encode(words)
+[<TestCase("no", ExpectedResult = "ml")>]
+[<TestCase("yes", ExpectedResult = "bvh", Ignore = "Remove to run test case")>]
+[<TestCase("OMG", ExpectedResult = "lnt", Ignore = "Remove to run test case")>]
+[<TestCase("mindblowingly", ExpectedResult = "nrmwy oldrm tob", Ignore = "Remove to run test case")>]
+[<TestCase("Testing, 1 2 3, testing.", ExpectedResult = "gvhgr mt123 gvhgr mt", Ignore = "Remove to run test case")>]
+[<TestCase("Truth is fiction.", ExpectedResult = "gifgs rhurx grlm", Ignore = "Remove to run test case")>]
+[<TestCase("The quick brown fox jumps over the lazy dog.", ExpectedResult = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt", Ignore = "Remove to run test case")>]
+let ``Encodes words using atbash cipher`` words =        
+    encode words

--- a/exercises/atbash-cipher/Example.fs
+++ b/exercises/atbash-cipher/Example.fs
@@ -2,28 +2,26 @@
 
 open System
 
-type Atbash() =
+let rec mapMaybe f list = 
+    match list with
+    | [] -> []
+    | x::xs -> 
+        match f x with
+        | Some(a) -> a :: mapMaybe f xs
+        | None -> mapMaybe f xs
 
-    let rec mapMaybe f list = 
-        match list with
-        | [] -> []
-        | x::xs -> 
-            match f x with
-            | Some(a) -> a :: mapMaybe f xs
-            | None -> mapMaybe f xs
+let stringFromChars (chars:char seq) = new String(chars |> Array.ofSeq)
+let chunksOfSize n xs = 
+    xs 
+    |> Seq.mapi(fun i x -> i / n, x)
+    |> Seq.groupBy fst
+    |> Seq.map (fun (_, g) -> Seq.map snd g)
 
-    let stringFromChars (chars:char seq) = new String(chars |> Array.ofSeq)
-    let chunksOfSize n xs = 
-        xs 
-        |> Seq.mapi(fun i x -> i / n, x)
-        |> Seq.groupBy fst
-        |> Seq.map (fun (_, g) -> Seq.map snd g)
+let mapLetter letter = if Char.IsDigit letter then (letter, letter) else (letter, (char)((int)'z' - (int)letter + (int)'a'))
+let lettersMap = ['a' .. 'z'] @ ['0'..'9'] |> List.map mapLetter |> Map.ofList
 
-    let mapLetter letter = if Char.IsDigit letter then (letter, letter) else (letter, (char)((int)'z' - (int)letter + (int)'a'))
-    let lettersMap = ['a' .. 'z'] @ ['0'..'9'] |> List.map mapLetter |> Map.ofList
-
-    let encodeLetter letter = Map.tryFind (Char.ToLower letter) lettersMap
-    let encodeInChunks = String.concat " " << Seq.map stringFromChars << chunksOfSize 5
-    let encodeStr = encodeInChunks << mapMaybe encodeLetter
+let encodeLetter letter = Map.tryFind (Char.ToLower letter) lettersMap
+let encodeInChunks = String.concat " " << Seq.map stringFromChars << chunksOfSize 5
+let encodeStr = encodeInChunks << mapMaybe encodeLetter
     
-    member this.encode (str:string) = encodeStr (str |> List.ofSeq)
+let encode (str:string) = str |> List.ofSeq |> encodeStr

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -3,53 +3,58 @@
 open NUnit.Framework
 open BankAccount
 
-type BankAccountTest() =
+[<Test>]
+let ``Returns empty balance after opening`` () =
     let account = BankAccount()
 
-    [<Test>]
-    member tests.Returns_empty_balance_after_opening() =
-        account.openAccount() |> ignore
+    account.openAccount() |> ignore
 
-        Assert.That(account.getBalance(), Is.EqualTo(0.0))
+    Assert.That(account.getBalance(), Is.EqualTo(0.0))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Check_basic_balance() =
-        account.openAccount() |> ignore
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Check basic balance`` () =
+    let account = BankAccount()
 
-        let openingBalance = account.getBalance()
+    account.openAccount() |> ignore
 
-        account.updateBalance(10.0)
+    let openingBalance = account.getBalance()
 
-        let updatedBalance = account.getBalance()
+    account.updateBalance(10.0)
 
-        Assert.That(openingBalance, Is.EqualTo(0.0))
-        Assert.That(updatedBalance, Is.EqualTo(10.0))
+    let updatedBalance = account.getBalance()
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Balance_can_increment_or_decrement() =
-        account.openAccount() |> ignore
+    Assert.That(openingBalance, Is.EqualTo(0.0))
+    Assert.That(updatedBalance, Is.EqualTo(10.0))
 
-        let openingBalance = account.getBalance()
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Balance can increment or decrement`` () =
+    let account = BankAccount()
 
-        account.updateBalance(10.0)
+    account.openAccount() |> ignore
 
-        let addedBalance = account.getBalance()
+    let openingBalance = account.getBalance()
 
-        account.updateBalance(-15.0)
+    account.updateBalance(10.0)
 
-        let subtractedBalance = account.getBalance()
+    let addedBalance = account.getBalance()
 
-        Assert.That(openingBalance, Is.EqualTo(0.0))
-        Assert.That(addedBalance, Is.EqualTo(10.0))
-        Assert.That(subtractedBalance, Is.EqualTo(-5.0))
+    account.updateBalance(-15.0)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Account_can_be_closed() =
-        account.openAccount() |> ignore
+    let subtractedBalance = account.getBalance()
 
-        account.closeAccount()
+    Assert.That(openingBalance, Is.EqualTo(0.0))
+    Assert.That(addedBalance, Is.EqualTo(10.0))
+    Assert.That(subtractedBalance, Is.EqualTo(-5.0))
 
-        Assert.That(account.Balance, Is.EqualTo(Option<float>.None))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Account can be closed`` () =
+    let account = BankAccount()
+
+    account.openAccount() |> ignore
+
+    account.closeAccount()
+
+    Assert.That(account.Balance, Is.EqualTo(Option<float>.None))

--- a/exercises/bank-account/Example.fs
+++ b/exercises/bank-account/Example.fs
@@ -1,20 +1,12 @@
 ﻿module BankAccount
 
+let inline (|?) (a: 'a option) b = if a.IsSome then a.Value else b
+
 type BankAccount() =
-    member val Balance = Option<float>.None with get, set
-
-    member this.openAccount() =
-        this.Balance <- Some 0.0
-        this.Balance.Value
-
-    member this.closeAccount() =
-        this.Balance <- None
-
-    member this.getBalance() =
-        this.Balance.Value
-
-    member this.updateBalance(newBalance: float) =
-        let balance = this.Balance.Value
-        let updatedBalance = balance + newBalance
-
-        this.Balance <- Some updatedBalance
+    let mutable balance = Option<float>.None
+    
+    member this.openAccount() = balance <- Some(0.0)
+    member this.updateBalance change = balance <- Some(this.getBalance() + change)
+    member this.getBalance() = balance |? 0.0
+    member this.closeAccount() = balance <- Option<float>.None
+    member this.Balance = balance

--- a/exercises/beer-song/BeerSongTest.fs
+++ b/exercises/beer-song/BeerSongTest.fs
@@ -2,52 +2,49 @@
 
 open NUnit.Framework
 open BeerSong
-
-type BeerSongTest() = 
-    let beersong = BeerSong()
-
-    [<Test>]
-    member tests.Test_a_typical_verse() =
-        let expected = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n"
-
-        Assert.That(beersong.verse(8), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_another_typical_verse() =
-        let expected = "3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n"
-
-        Assert.That(beersong.verse(3), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_verse_1() =
-        let expected = "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n"
-
-        Assert.That(beersong.verse(1), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_verse_2() =
-        let expected = "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
-
-        Assert.That(beersong.verse(2), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_verse_0() =
-        let expected = "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
-
-        Assert.That(beersong.verse(0), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_several_verses() =
-        let expected = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n\n7 bottles of beer on the wall, 7 bottles of beer.\nTake one down and pass it around, 6 bottles of beer on the wall.\n\n6 bottles of beer on the wall, 6 bottles of beer.\nTake one down and pass it around, 5 bottles of beer on the wall.\n\n"
-
-        Assert.That(beersong.verses(8, 6), Is.EqualTo(expected))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_the_whole_song() =
-        Assert.That(beersong.verses(99, 0), Is.EqualTo(beersong.sing()))
+    
+[<Test>]
+let ``Test a typical verse`` () = 
+    let expected = 
+        "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n"
+    Assert.That(verse 8, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test another typical verse`` () = 
+    let expected = 
+        "3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n"
+    Assert.That(verse 3, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test verse 1`` () = 
+    let expected = 
+        "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n"
+    Assert.That(verse 1, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test verse 2`` () = 
+    let expected = 
+        "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
+    Assert.That(verse 2, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test verse 0`` () = 
+    let expected = 
+        "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
+    Assert.That(verse 0, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test several verses`` () = 
+    let expected = 
+        "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n\n7 bottles of beer on the wall, 7 bottles of beer.\nTake one down and pass it around, 6 bottles of beer on the wall.\n\n6 bottles of beer on the wall, 6 bottles of beer.\nTake one down and pass it around, 5 bottles of beer on the wall.\n\n"
+    Assert.That(verses 8 6, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test the whole song`` () = 
+    Assert.That(verses 99 0, Is.EqualTo(sing))

--- a/exercises/beer-song/Example.fs
+++ b/exercises/beer-song/Example.fs
@@ -1,18 +1,15 @@
 ﻿module BeerSong
 
-type BeerSong() = 
-    member this.verse(number: int) =
-        match number with
-            | 0 -> "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
-            | 1 -> System.String.Format("{0} bottle of beer on the wall, {0} bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n", number)
-            | 2 -> System.String.Format("{0} bottles of beer on the wall, {0} bottles of beer.\nTake one down and pass it around, {1} bottle of beer on the wall.\n", number, number - 1)
-            | _ -> System.String.Format("{0} bottles of beer on the wall, {0} bottles of beer.\nTake one down and pass it around, {1} bottles of beer on the wall.\n", number, number - 1)
+let verse n = 
+    match n with
+    | 0 -> "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
+    | 1 -> "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n"
+    | 2 -> "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
+    | _ -> sprintf "%d bottles of beer on the wall, %d bottles of beer.\nTake one down and pass it around, %d bottles of beer on the wall.\n" n n (n-1)
 
-    member this.sing() =
-        this.verses(99, 0)
+let verses stop start = 
+    [stop .. -1 .. start] 
+    |> List.map (fun i -> verse i + "\n") 
+    |> List.reduce (+)
 
-    member this.verses(starting: int, ending: int) =
-        [ending..starting]
-            |> List.rev
-            |> List.map(fun item -> this.verse(item) + "\n")
-            |> List.fold(fun accumulator element -> accumulator + element) ""
+let sing = verses 99 0

--- a/exercises/binary-search-tree/BinarySearchTreeTest.fs
+++ b/exercises/binary-search-tree/BinarySearchTreeTest.fs
@@ -6,20 +6,20 @@ open BinarySearchTree
 let value node = node.value
 
 [<Test>]
-let ``Data is retained``() =
+let ``Data is retained`` () =
     let tree = singleton(4)
     Assert.That(tree |> value, Is.EqualTo(4))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Inserting less``() =
+let ``Inserting less`` () =
     let tree = singleton(4) |> insert 2
     Assert.That(tree |> value, Is.EqualTo(4))
     Assert.That(tree.left |> Option.map value, Is.EqualTo(Some 2))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Inserting same``() =
+let ``Inserting same`` () =
     let tree = singleton(4) |> insert 4
     Assert.That(tree |> value, Is.EqualTo(4))
     Assert.That(tree.left |> Option.map value, Is.EqualTo(Some 4))
@@ -41,28 +41,28 @@ let ``Complex tree()`` =
     Assert.That(tree.left |> Option.bind (fun x -> x.right) |> Option.map value, Is.EqualTo(Some 3))
     Assert.That(tree.right |> Option.map value, Is.EqualTo(6))
     Assert.That(tree.right |> Option.bind (fun x -> x.left) |> Option.map value, Is.EqualTo(Some 5))
-    Assert.That(tree.right |> Option.bind (fun x -> x.right) |> Option.map value, Is.EqualTo(Some 7))
+    Assert.That(tree.right |> Option.bind (fun x -> x.right) |> Option.map value, Is.EqualTo(7))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Iterating one element``() =
+let ``Iterating one element`` () =
     let elements = singleton(4) |> toList
     Assert.That(elements, Is.EqualTo([4]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Iterating over smaller element``() =
+let ``Iterating over smaller element`` () =
     let elements = fromList [4; 2] |> toList
     Assert.That(elements, Is.EqualTo([2; 4]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Iterating over larger element``() =
+let ``Iterating over larger element`` () =
     let elements = fromList [4; 5] |> toList
     Assert.That(elements, Is.EqualTo([4; 5]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Iterating over complex element``() =
+let ``Iterating over complex element`` () =
     let elements = fromList [4; 2; 1; 3; 6; 7; 5] |> toList
     Assert.That(elements, Is.EqualTo([1; 2; 3; 4; 5; 6; 7])) 

--- a/exercises/binary/BinaryTests.fs
+++ b/exercises/binary/BinaryTests.fs
@@ -2,24 +2,22 @@
 
 open NUnit.Framework
 open Binary
-
-type BinaryTests() =
     
-    [<TestCase("1", ExpectedResult = 1)>]
-    [<TestCase("10", ExpectedResult = 2, Ignore = "Remove to run test case")>]
-    [<TestCase("11", ExpectedResult = 3, Ignore = "Remove to run test case")>]
-    [<TestCase("100", ExpectedResult = 4, Ignore = "Remove to run test case")>]
-    [<TestCase("1001", ExpectedResult = 9, Ignore = "Remove to run test case")>]
-    [<TestCase("11010", ExpectedResult = 26, Ignore = "Remove to run test case")>]
-    [<TestCase("10001101000", ExpectedResult = 1128, Ignore = "Remove to run test case")>]
-    member tests.Binary_converts_to_decimal(input) =
-        Binary(input).toDecimal()
+[<TestCase("1", ExpectedResult = 1)>]
+[<TestCase("10", ExpectedResult = 2, Ignore = "Remove to run test case")>]
+[<TestCase("11", ExpectedResult = 3, Ignore = "Remove to run test case")>]
+[<TestCase("100", ExpectedResult = 4, Ignore = "Remove to run test case")>]
+[<TestCase("1001", ExpectedResult = 9, Ignore = "Remove to run test case")>]
+[<TestCase("11010", ExpectedResult = 26, Ignore = "Remove to run test case")>]
+[<TestCase("10001101000", ExpectedResult = 1128, Ignore = "Remove to run test case")>]
+let ``Binary converts to decimal`` (input: string) =
+    toDecimal input
 
-    [<TestCase("carrot", Ignore = "Remove to run test case")>]
-    [<TestCase("2", Ignore = "Remove to run test case")>]
-    [<TestCase("5", Ignore = "Remove to run test case")>]
-    [<TestCase("9", Ignore = "Remove to run test case")>]
-    [<TestCase("134678", Ignore = "Remove to run test case")>]
-    [<TestCase("abc10z", Ignore = "Remove to run test case")>]
-    member tests.Invalid_binary_is_decimal_0(input) =
-        Assert.That(Binary(input).toDecimal(), Is.EqualTo(0))
+[<TestCase("carrot", Ignore = "Remove to run test case")>]
+[<TestCase("2", Ignore = "Remove to run test case")>]
+[<TestCase("5", Ignore = "Remove to run test case")>]
+[<TestCase("9", Ignore = "Remove to run test case")>]
+[<TestCase("134678", Ignore = "Remove to run test case")>]
+[<TestCase("abc10z", Ignore = "Remove to run test case")>]
+let ``Invalid binary is decimal 0`` (input: string) =
+    Assert.That(toDecimal input, Is.EqualTo(0))

--- a/exercises/binary/Example.fs
+++ b/exercises/binary/Example.fs
@@ -1,14 +1,13 @@
 ﻿module Binary
 
-type Binary(input: string) =
-    let rec toDecimalLoop acc input = 
-        if input = "" then acc
-        else 
-            let head = input.Chars 0
-            let tail = input.Substring 1
-            match head with
-                | '0' -> toDecimalLoop (acc * 2) tail
-                | '1' -> toDecimalLoop (acc * 2 + 1) tail
-                | _   -> 0   
+let isValid char = 
+    match char with
+    | '0' | '1' -> true
+    | _  -> false
 
-    member this.toDecimal() = toDecimalLoop 0 input
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal(input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 2 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/bob/BobTest.fs
+++ b/exercises/bob/BobTest.fs
@@ -2,79 +2,77 @@
 
 open NUnit.Framework
 open Bob
-
-type BobTest() =
     
-    [<Test>]
-    member tests.Stating_something() =
-        Assert.That(Bob("Tom-ay-to, tom-aaaah-to.").hey(), Is.EqualTo("Whatever."))
+[<Test>]
+let ``Stating something`` () =
+    Assert.That(hey "Tom-ay-to, tom-aaaah-to.", Is.EqualTo("Whatever."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Shouting() =
-        Assert.That(Bob("WATCH OUT!").hey(), Is.EqualTo("Whoa, chill out!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Shouting`` () =
+    Assert.That(hey "WATCH OUT!", Is.EqualTo("Whoa, chill out!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Asking_a_question() =
-        Assert.That(Bob("Does this cryogenic chamber make me look fat?").hey(), Is.EqualTo("Sure."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Asking a question`` () =
+    Assert.That(hey "Does this cryogenic chamber make me look fat?", Is.EqualTo("Sure."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Asking_a_numeric_question() =
-        Assert.That(Bob("You are, what, like 15?").hey(), Is.EqualTo("Sure."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Asking a numeric question`` () =
+    Assert.That(hey "You are, what, like 15?", Is.EqualTo("Sure."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Forceful_questions() =
-        Assert.That(Bob("WHAT THE HELL WERE YOU THINKING?").hey(), Is.EqualTo("Whoa, chill out!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Forceful questions`` () =
+    Assert.That(hey "WHAT THE HELL WERE YOU THINKING?", Is.EqualTo("Whoa, chill out!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Shouting_numbers() =
-        Assert.That(Bob("1, 2, 3 GO!").hey(), Is.EqualTo("Whoa, chill out!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Shouting numbers`` () =
+    Assert.That(hey "1, 2, 3 GO!", Is.EqualTo("Whoa, chill out!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Only_numbers() =
-        Assert.That(Bob("1, 2, 3").hey(), Is.EqualTo("Whatever."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Only numbers`` () =
+    Assert.That(hey "1, 2, 3", Is.EqualTo("Whatever."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Question_only_with_numbers() =
-        Assert.That(Bob("4?").hey(), Is.EqualTo("Sure."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Question only with numbers`` () =
+    Assert.That(hey "4?", Is.EqualTo("Sure."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Shouting_with_special_characters() =
-        Assert.That(Bob("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!").hey(), Is.EqualTo("Whoa, chill out!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Shouting with special characters`` () =
+    Assert.That(hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!", Is.EqualTo("Whoa, chill out!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Shouting_with_no_exlamation_mark() =
-        Assert.That(Bob("I HATE YOU").hey(), Is.EqualTo("Whoa, chill out!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Shouting with no exlamation mark`` () =
+    Assert.That(hey "I HATE YOU", Is.EqualTo("Whoa, chill out!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Statement_containing_question_mark() =
-        Assert.That(Bob("Ending with ? means a question.").hey(), Is.EqualTo("Whatever."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Statement containing question mark`` () =
+    Assert.That(hey "Ending with ? means a question.", Is.EqualTo("Whatever."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Prattling_on() =
-        Assert.That(Bob("Wait! Hang on. Are you going to be OK?").hey(), Is.EqualTo("Sure."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Prattling on`` () =
+    Assert.That(hey "Wait! Hang on. Are you going to be OK?", Is.EqualTo("Sure."))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Silence() =
-        Assert.That(Bob("").hey(), Is.EqualTo("Fine. Be that way!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Silence`` () =
+    Assert.That(hey "", Is.EqualTo("Fine. Be that way!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Prolonged_silence() =
-        Assert.That(Bob("    ").hey(), Is.EqualTo("Fine. Be that way!"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Prolonged silence`` () =
+    Assert.That(hey "    ", Is.EqualTo("Fine. Be that way!"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Multiple_line_question() =
-        Assert.That(Bob("Does this cryogenic chamber make me look fat?\nno").hey(), Is.EqualTo("Whatever."))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Multiple line question`` () =
+    Assert.That(hey "Does this cryogenic chamber make me look fat?\nno", Is.EqualTo("Whatever."))

--- a/exercises/bob/Example.fs
+++ b/exercises/bob/Example.fs
@@ -1,22 +1,15 @@
 ﻿module Bob
 
-type Bob(statement: string) =
-    let isSilence(statement: string) =
-        System.String.IsNullOrWhiteSpace(statement)
-    
-    let isYelling(statement: string) =
-        statement.ToUpper() = statement && System.Text.RegularExpressions.Regex.IsMatch(statement, "[a-zA-Z]+")
+open System
 
-    let isQuestion(statement: string) =
-        statement.EndsWith("?")
+let hey(input: string) = 
+    let isEmpty = String.IsNullOrWhiteSpace input
+    let isYell = Seq.exists Char.IsLetter input && input = input.ToUpperInvariant()
+    let isQuestion = input.EndsWith "?"
 
-    member this.Statement = statement
+    match input with 
+        | _ when isEmpty -> "Fine. Be that way!"
+        | _ when isYell -> "Whoa, chill out!"
+        | _ when isQuestion -> "Sure."
+        | _ -> "Whatever."
 
-    member this.hey() =
-        match isSilence(this.Statement) with
-            | true -> "Fine. Be that way!"
-            | false -> (match isYelling(this.Statement) with
-                            | true -> "Whoa, chill out!"
-                            | false -> (match isQuestion(this.Statement) with
-                                            | true -> "Sure."
-                                            | false -> "Whatever."))

--- a/exercises/clock/ClockTests.fs
+++ b/exercises/clock/ClockTests.fs
@@ -4,83 +4,82 @@ open System
 open NUnit.Framework
 open Clock
 
-type ClockTests() =
-    [<TestCase(8, "08:00")>]
-    [<TestCase(9, "09:00", Ignore = "Remove to run test case")>]
-    member tests.Prints_the_hour(hours, expected) =
-        let clock = new Clock(hours)
-        Assert.That(clock.ToString(), Is.EqualTo(expected))
+[<TestCase(8, "08:00")>]
+[<TestCase(9, "09:00", Ignore = "Remove to run test case")>]
+let ``Prints the hour`` (hours: int, expected: string) =
+    let clock = new Clock(hours)
+    Assert.That(clock.ToString(), Is.EqualTo(expected))
 
-    [<TestCase(11, 9, "11:09", Ignore = "Remove to run test case")>]
-    [<TestCase(11, 19, "11:19", Ignore = "Remove to run test case")>]
-    member tests.Prints_past_the_hour(hours, minutes, expected) =
-        let clock = new Clock(hours, minutes)
-        Assert.That(clock.ToString(), Is.EqualTo(expected))
+[<TestCase(11, 9, "11:09", Ignore = "Remove to run test case")>]
+[<TestCase(11, 19, "11:19", Ignore = "Remove to run test case")>]
+let ``Prints past the hour`` (hours: int) (minutes: int) (expected: string) =
+    let clock = new Clock(hours, minutes)
+    Assert.That(clock.ToString(), Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Can_add_minutes() =
-        let clock = new Clock(10)
-        let added = clock.add(3)
-        Assert.That(added.ToString(), Is.EqualTo("10:03"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can add minutes`` () =
+    let clock = new Clock(10)
+    let added = clock.add(3)
+    Assert.That(added.ToString(), Is.EqualTo("10:03"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Can_add_over_an_hour() =
-        let clock = new Clock(10)
-        let added = clock.add(63)
-        Assert.That(added.ToString(), Is.EqualTo("11:03"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can add over an hour`` () =
+    let clock = new Clock(10)
+    let added = clock.add(63)
+    Assert.That(added.ToString(), Is.EqualTo("11:03"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Can_subtract_minutes() =
-        let clock = new Clock(10, 3)
-        let subtracted = clock.subtract(3)
-        Assert.That(subtracted.ToString(), Is.EqualTo("10:00"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can subtract minutes`` () =
+    let clock = new Clock(10, 3)
+    let subtracted = clock.subtract(3)
+    Assert.That(subtracted.ToString(), Is.EqualTo("10:00"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Can_subtract_to_previous_hour() =
-        let clock = new Clock(10, 3)
-        let subtracted = clock.subtract(30)
-        Assert.That(subtracted.ToString(), Is.EqualTo("09:33"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can subtract to previous hour`` () =
+    let clock = new Clock(10, 3)
+    let subtracted = clock.subtract(30)
+    Assert.That(subtracted.ToString(), Is.EqualTo("09:33"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Can_subtract_over_an_hour() =
-        let clock = new Clock(10, 3)
-        let subtracted = clock.subtract(70)
-        Assert.That(subtracted.ToString(), Is.EqualTo("08:53"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can subtract over an hour`` () =
+    let clock = new Clock(10, 3)
+    let subtracted = clock.subtract(70)
+    Assert.That(subtracted.ToString(), Is.EqualTo("08:53"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Wraps_around_midnight() =
-        let clock = new Clock(23, 59)
-        let added = clock.add(2)
-        Assert.That(added.ToString(), Is.EqualTo("00:01"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Wraps around midnight`` () =
+    let clock = new Clock(23, 59)
+    let added = clock.add(2)
+    Assert.That(added.ToString(), Is.EqualTo("00:01"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Wraps_around_midnight_backwards() =
-        let clock = new Clock(0, 1)
-        let subtracted = clock.subtract(2)
-        Assert.That(subtracted.ToString(), Is.EqualTo("23:59"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Wraps around midnight backwards`` () =
+    let clock = new Clock(0, 1)
+    let subtracted = clock.subtract(2)
+    Assert.That(subtracted.ToString(), Is.EqualTo("23:59"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Midnight_is_zero_hundred_hours() =
-        let clock = new Clock(24)
-        Assert.That(clock.ToString(), Is.EqualTo("00:00"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Midnight is zero hundred hours`` () =
+    let clock = new Clock(24)
+    Assert.That(clock.ToString(), Is.EqualTo("00:00"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Sixty_minutes_is_next_hour() =
-        let clock = new Clock(1, 60)
-        Assert.That(clock.ToString(), Is.EqualTo("02:00"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Sixty minutes is next hour`` () =
+    let clock = new Clock(1, 60)
+    Assert.That(clock.ToString(), Is.EqualTo("02:00"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Clocks_with_same_time_are_equal() =
-        let clock1 = new Clock(14, 30)
-        let clock2 = new Clock(14, 30)
-        Assert.That(clock1, Is.EqualTo(clock2))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Clocks with same time are equal`` () =
+    let clock1 = new Clock(14, 30)
+    let clock2 = new Clock(14, 30)
+    Assert.That(clock1, Is.EqualTo(clock2))

--- a/exercises/crypto-square/CryptoSquareTests.fs
+++ b/exercises/crypto-square/CryptoSquareTests.fs
@@ -3,81 +3,66 @@ module CryptoSquareTests
 open NUnit.Framework
 open CryptoSquare
 
-type CryptoSquareTests() =
+[<Test>]
+let ``Strange characters are stripped during normalization`` () =
+    Assert.That(normalizePlaintext "s#$%^&plunk", Is.EqualTo("splunk"))
 
-    [<Test>]
-    member tests.Strange_characters_are_stripped_during_normalization() =
-        let crypto = new CryptoSquare("s#$%^&plunk")
-        Assert.That<string>(crypto.normalizePlaintext, Is.EqualTo("splunk"))
+[<Test>]
+[<Ignore("Remove to run test")>]   
+let ``Letters are lowercased during normalization`` () =
+    Assert.That(normalizePlaintext "WHOA HEY!", Is.EqualTo("whoahey"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Letters_are_lowercased_during_normalization() =
-        let crypto = new CryptoSquare("WHOA HEY!")
-        Assert.That<string>(crypto.normalizePlaintext, Is.EqualTo("whoahey"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Numbers are kept during normalization`` () =
+    Assert.That(normalizePlaintext "1, 2, 3, GO!", Is.EqualTo("123go"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Numbers_are_kept_during_normalization() =
-        let crypto = new CryptoSquare("1, 2, 3, GO!")
-        Assert.That<string>(crypto.normalizePlaintext, Is.EqualTo("123go"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Smallest square size is 2`` () =
+    Assert.That(size "1234", Is.EqualTo(2))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Smallest_square_size_is_2() =
-        let crypto = new CryptoSquare("1234")
-        Assert.That<int>(crypto.size, Is.EqualTo(2))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Size of text whose length is a perfect square is its square root`` () =
+    Assert.That(size "123456789", Is.EqualTo(3))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Size_of_text_whose_length_is_a_perfect_square_is_its_square_root() =
-        let crypto = new CryptoSquare("123456789")
-        Assert.That<int>(crypto.size, Is.EqualTo(3))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Size of text whose length is not a perfect square is next biggest square root`` () =
+    Assert.That(size "123456789abc", Is.EqualTo(4))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Size_of_text_whose_length_is_not_a_perfect_square_is_next_biggest_square_root() =
-        let crypto = new CryptoSquare("123456789abc")
-        Assert.That<int>(crypto.size, Is.EqualTo(4))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Size is determined by normalized text`` () =
+    Assert.That(size "Oh hey, this is nuts!", Is.EqualTo(4))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Size_is_determined_by_normalized_text() =
-        let crypto = new CryptoSquare("Oh hey, this is nuts!")
-        Assert.That<int>(crypto.size, Is.EqualTo(4))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Segments are split by square size`` () =
+    Assert.That(plaintextSegments "Never vex thine heart with idle woes", Is.EqualTo(["neverv"; "exthin"; "eheart"; "withid"; "lewoes"]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Segments_are_split_by_square_size() =
-        let crypto = new CryptoSquare("Never vex thine heart with idle woes")
-        Assert.That(crypto.plaintextSegments(), Is.EqualTo(["neverv"; "exthin"; "eheart"; "withid"; "lewoes"]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Segments are split by square size until text runs out`` () =
+    Assert.That(plaintextSegments "ZOMG! ZOMBIES!!!", Is.EqualTo(["zomg"; "zomb"; "ies"]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Segments_are_split_by_square_size_until_text_runs_out() =
-        let crypto = new CryptoSquare("ZOMG! ZOMBIES!!!")
-        Assert.That(crypto.plaintextSegments(), Is.EqualTo(["zomg"; "zomb"; "ies"]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Ciphertext combines text by column`` () =
+    Assert.That(ciphertext "First, solve the problem. Then, write the code.", Is.EqualTo("foeewhilpmrervrticseohtottbeedshlnte"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Ciphertext_combines_text_by_column() =
-        let crypto = new CryptoSquare("First, solve the problem. Then, write the code.")
-        Assert.That(crypto.ciphertext(), Is.EqualTo("foeewhilpmrervrticseohtottbeedshlnte"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Ciphertext skips cells with no text`` () =
+    Assert.That(ciphertext "Time is an illusion. Lunchtime doubly so.", Is.EqualTo("tasneyinicdsmiohooelntuillibsuuml"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Ciphertext_skips_cells_with_no_text() =
-        let crypto = new CryptoSquare("Time is an illusion. Lunchtime doubly so.")
-        Assert.That(crypto.ciphertext(), Is.EqualTo("tasneyinicdsmiohooelntuillibsuuml"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Normalized ciphertext is split by 5`` () =
+    Assert.That(normalizeCiphertext "Vampires are people too!", Is.EqualTo("vrel aepe mset paoo irpo"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Normalized_ciphertext_is_split_by_5() =
-        let crypto = new CryptoSquare("Vampires are people too!")
-        Assert.That(crypto.normalizeCiphertext(), Is.EqualTo("vrel aepe mset paoo irpo"))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Normalized_ciphertext_not_exactly_divisible_by_5_spills_into_a_smaller_segment() =
-        let crypto = new CryptoSquare("Madness, and then illumination.")
-        Assert.That(crypto.normalizeCiphertext(), Is.EqualTo("msemo aanin dnin ndla etlt shui"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Normalized ciphertext not exactly divisible by 5 spills into a smaller segment`` () =
+    Assert.That(normalizeCiphertext "Madness, and then illumination.", Is.EqualTo("msemo aanin dnin ndla etlt shui"))

--- a/exercises/crypto-square/Example.fs
+++ b/exercises/crypto-square/Example.fs
@@ -2,24 +2,43 @@
 
 open System
 
-type CryptoSquare(input) = 
+let charsToString chars = new String(chars |> Array.ofSeq)
 
-    let charsToString chars = new String(chars |> Array.ofSeq)
+let chunksOfSize n seq = 
+    seq 
+    |> Seq.mapi(fun i x -> i / n, x)
+    |> Seq.groupBy fst
+    |> Seq.map (fun (_, g) -> g |> Seq.map snd |> charsToString)
 
-    let chunksOfSize n seq = 
-        seq 
-        |> Seq.mapi(fun i x -> i / n, x)
-        |> Seq.groupBy fst
-        |> Seq.map (fun (_, g) -> g |> Seq.map snd |> charsToString)
+let transpose seq = 
+    seq
+    |> Seq.collect(fun s -> s |> Seq.mapi(fun i e -> (i, e)))
+    |> Seq.groupBy(fst)
+    |> Seq.map(fun (_, s) -> s |> Seq.map snd |> charsToString)    
 
-    let transpose seq = 
-        seq
-        |> Seq.collect(fun s -> s |> Seq.mapi(fun i e -> (i, e)))
-        |> Seq.groupBy(fst)
-        |> Seq.map(fun (_, s) -> s |> Seq.map snd |> charsToString)    
+let normalizePlaintext (input: string) = seq { for c in input do if Char.IsLetterOrDigit c then yield Char.ToLowerInvariant c } |> charsToString
 
-    member this.size() = this.normalizePlaintext() |> String.length |> float |> Math.Sqrt |> ceil |> int
-    member this.normalizePlaintext() = seq { for c in input do if Char.IsLetterOrDigit c then yield Char.ToLowerInvariant c } |> charsToString
-    member this.plaintextSegments() = chunksOfSize (this.size()) (this.normalizePlaintext()) |> List.ofSeq
-    member this.ciphertext() = this.plaintextSegments() |> transpose |> String.concat ""
-    member this.normalizeCiphertext() = this.plaintextSegments() |> transpose |> String.concat " "
+let size (input: string) = 
+    input 
+    |> normalizePlaintext 
+    |> String.length 
+    |> float 
+    |> Math.Sqrt 
+    |> ceil 
+    |> int
+
+let plaintextSegments (input: string) = 
+    chunksOfSize (size input) (normalizePlaintext input) 
+    |> List.ofSeq
+
+let ciphertext (input: string) = 
+    input 
+    |> plaintextSegments 
+    |> transpose 
+    |> String.concat ""
+
+let normalizeCiphertext (input: string) = 
+    input 
+    |> plaintextSegments 
+    |> transpose 
+    |> String.concat " "

--- a/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
@@ -2,49 +2,47 @@
 
 open NUnit.Framework
 open DifferenceOfSquares
-
-type DifferenceOfSquaresTests() =
     
-    [<Test>]
-    member test.Square_of_sums_to_5() =
-        Assert.That(DifferenceOfSquares(5).squareOfSums(), Is.EqualTo(225))
+[<Test>]
+let ``Square of sums to 5`` () =
+    Assert.That(squareOfSums 5, Is.EqualTo(225))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Sum_of_squares_to_5() =
-        Assert.That(DifferenceOfSquares(5).sumOfSquares(), Is.EqualTo(55))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Sum of squares to 5`` () =
+    Assert.That(sumOfSquares 5, Is.EqualTo(55))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Difference_of_sums_to_5() =
-        Assert.That(DifferenceOfSquares(5).difference(), Is.EqualTo(170))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Difference of sums to 5`` () =
+    Assert.That(difference 5, Is.EqualTo(170))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Square_of_sums_to_10() =
-        Assert.That(DifferenceOfSquares(10).squareOfSums(), Is.EqualTo(3025))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Square of sums to 10`` () =
+    Assert.That(squareOfSums 10, Is.EqualTo(3025))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Sum_of_squares_to_10() =
-        Assert.That(DifferenceOfSquares(10).sumOfSquares(), Is.EqualTo(385))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Sum of squares to 10`` () =
+    Assert.That(sumOfSquares 10, Is.EqualTo(385))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Difference_of_sums_to_10() =
-        Assert.That(DifferenceOfSquares(10).difference(), Is.EqualTo(2640))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Difference of sums to 10`` () =
+    Assert.That(difference 10, Is.EqualTo(2640))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Square_of_sums_to_100() =
-        Assert.That(DifferenceOfSquares(100).squareOfSums(), Is.EqualTo(25502500))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Square of sums to 100`` () =
+    Assert.That(squareOfSums 100, Is.EqualTo(25502500))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Sum_of_squares_to_100() =
-        Assert.That(DifferenceOfSquares(100).sumOfSquares(), Is.EqualTo(338350))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Sum of squares to 100`` () =
+    Assert.That(sumOfSquares 100, Is.EqualTo(338350))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Difference_of_sums_to_100() =
-        Assert.That(DifferenceOfSquares(100).difference(), Is.EqualTo(25164150))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Difference of sums to 100`` () =
+    Assert.That(difference 100, Is.EqualTo(25164150))

--- a/exercises/difference-of-squares/Example.fs
+++ b/exercises/difference-of-squares/Example.fs
@@ -1,15 +1,7 @@
 ﻿module DifferenceOfSquares
 
-type DifferenceOfSquares(max: int) =
-    member this.squareOfSums() =
-        [1..max]
-            |> List.sum
-            |> fun sum -> sum * sum
+let square x = x * x
 
-    member this.sumOfSquares() =
-        [1..max]
-            |> List.map(fun num -> num * num)
-            |> List.sum
-
-    member this.difference() =
-        this.squareOfSums() - this.sumOfSquares()
+let squareOfSums (number: int) = [1..number] |> List.sum |> square
+let sumOfSquares (number: int) = [1..number] |> List.map square |> List.sum
+let difference (number: int) = squareOfSums number - sumOfSquares number

--- a/exercises/etl/ETLTests.fs
+++ b/exercises/etl/ETLTests.fs
@@ -3,41 +3,39 @@
 open NUnit.Framework
 open ETL
 
-type ETLTests() =
+[<Test>]
+let ``Transforms one value`` () =
+    let old = [(1, ["A"])] |> Map.ofSeq
+    let expected = [("a", 1)] |> Map.ofSeq
+    Assert.That(transform old, Is.EqualTo(expected))
 
-    [<Test>]
-    member tests.Transforms_one_value() =
-        let old = [(1, ["A"])] |> Map.ofSeq
-        let expected = [("a", 1)] |> Map.ofSeq
-        Assert.That(ETL().transform(old), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Transforms multiple values`` () =
+    let old = [(1, ["A"; "E"; "I"; "O"; "U"])] |> Map.ofSeq
+    let expected = [("a", 1); ("e", 1); ("i", 1); ("o", 1); ("u", 1)] |> Map.ofSeq
+    Assert.That(transform old, Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Transforms_multiple_values() =
-        let old = [(1, ["A"; "E"; "I"; "O"; "U"])] |> Map.ofSeq
-        let expected = [("a", 1); ("e", 1); ("i", 1); ("o", 1); ("u", 1)] |> Map.ofSeq
-        Assert.That(ETL().transform(old), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Transforms multiple keys`` () =
+    let old = [(1, ["A"; "E"]); (2, ["D"; "G"])] |> Map.ofSeq
+    let expected = [("a", 1); ("e", 1); ("d", 2); ("g", 2); ] |> Map.ofSeq
+    Assert.That(transform old, Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Transforms_multiple_keys() =
-        let old = [(1, ["A"; "E"]); (2, ["D"; "G"])] |> Map.ofSeq
-        let expected = [("a", 1); ("e", 1); ("d", 2); ("g", 2); ] |> Map.ofSeq
-        Assert.That(ETL().transform(old), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Transforms a full dataset`` () =
+    let old = [(1, ["A"; "E"; "I"; "O"; "U"; "L"; "N"; "R"; "S"; "T"]); 
+                (2, ["D"; "G"]); 
+                (3, ["B"; "C"; "M"; "P"]); 
+                (4, ["F"; "H"; "V"; "W"; "Y"]); 
+                (5, ["K"]); 
+                (8, ["J"; "X"]); 
+                (10, ["Q"; "Z"])] |> Map.ofSeq
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Transforms_a_full_dataset() =
-        let old = [(1, ["A"; "E"; "I"; "O"; "U"; "L"; "N"; "R"; "S"; "T"]); 
-                   (2, ["D"; "G"]); 
-                   (3, ["B"; "C"; "M"; "P"]); 
-                   (4, ["F"; "H"; "V"; "W"; "Y"]); 
-                   (5, ["K"]); 
-                   (8, ["J"; "X"]); 
-                   (10, ["Q"; "Z"])] |> Map.ofSeq
+    let expected = [("a", 1);  ("b", 3);  ("c", 3);  ("d", 2);  ("e", 1);  ("f", 4);  ("g", 2);  ("h", 4);  ("i", 1); 
+                    ("j", 8);  ("k", 5);  ("l", 1);  ("m", 3);  ("n", 1);  ("o", 1);  ("p", 3);  ("q", 10);  ("r", 1); 
+                    ("s", 1);  ("t", 1);  ("u", 1);  ("v", 4);  ("w", 4);  ("x", 8);  ("y", 4);  ("z", 10 )] |> Map.ofSeq
 
-        let expected = [("a", 1);  ("b", 3);  ("c", 3);  ("d", 2);  ("e", 1);  ("f", 4);  ("g", 2);  ("h", 4);  ("i", 1); 
-                        ("j", 8);  ("k", 5);  ("l", 1);  ("m", 3);  ("n", 1);  ("o", 1);  ("p", 3);  ("q", 10);  ("r", 1); 
-                        ("s", 1);  ("t", 1);  ("u", 1);  ("v", 4);  ("w", 4);  ("x", 8);  ("y", 4);  ("z", 10 )] |> Map.ofSeq
-
-        Assert.That(ETL().transform(old), Is.EqualTo(expected));
+    Assert.That(transform old, Is.EqualTo(expected))

--- a/exercises/etl/Example.fs
+++ b/exercises/etl/Example.fs
@@ -1,7 +1,6 @@
 ﻿module ETL
 
-type ETL() =
-    member this.transform(input:Map<int, string list>): Map<string, int> = 
-        let transformElement num acc (str:string) = Map.add (str.ToLowerInvariant()) num acc
-        Map.fold (fun acc num strings -> List.fold (transformElement num) acc strings) Map.empty input
+let transform (input:Map<int, string list>): Map<string, int> = 
+    let transformElement num acc (str:string) = Map.add (str.ToLowerInvariant()) num acc
+    Map.fold (fun acc num strings -> List.fold (transformElement num) acc strings) Map.empty input
         

--- a/exercises/gigasecond/Example.fs
+++ b/exercises/gigasecond/Example.fs
@@ -1,5 +1,7 @@
 ﻿module Gigasecond
 
-type Gigasecond(birthDate: System.DateTime) =
-    member this.Date() =
-        birthDate.AddSeconds(1000000000.0)
+open System
+
+let gigasecond (beginDate: DateTime) = 
+    let gigaSecondDateTime = beginDate.AddSeconds(1000000000.0) 
+    gigaSecondDateTime.Date

--- a/exercises/gigasecond/GigasecondTest.fs
+++ b/exercises/gigasecond/GigasecondTest.fs
@@ -2,25 +2,21 @@
 
 open NUnit.Framework
 open Gigasecond
-
-type GigasecondTest() =
+open System
     
-    [<Test>]
-    member tests.First_date() =
-        let gigasecond = Gigasecond(System.DateTime(2011, 4, 25, 0, 0, 0, System.DateTimeKind.Utc))
+[<Test>]
+let ``First date`` () =
+    let input = DateTime(2011, 4, 25)
+    Assert.That(gigasecond input, Is.EqualTo(DateTime(2043, 1, 1)))
 
-        Assert.That<System.DateTime>(gigasecond.Date, Is.EqualTo(System.DateTime(2043, 1, 1, 1, 46, 40, System.DateTimeKind.Utc)))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Another date`` () =
+    let input = DateTime(1977, 6, 13)
+    Assert.That(gigasecond input, Is.EqualTo(DateTime(2009, 2, 19)))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Another_date() =
-        let gigasecond = Gigasecond(System.DateTime(1977, 6, 13, 0, 0, 0, System.DateTimeKind.Utc))
-
-        Assert.That<System.DateTime>(gigasecond.Date, Is.EqualTo(System.DateTime(2009, 2, 19, 1, 46, 40, System.DateTimeKind.Utc)))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Yet_another_date() =
-        let gigasecond = Gigasecond(System.DateTime(1959, 7, 19, 0, 0, 0, System.DateTimeKind.Utc))
-
-        Assert.That<System.DateTime>(gigasecond.Date, Is.EqualTo(System.DateTime(1991, 3, 27, 1, 46, 40, System.DateTimeKind.Utc)))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Yet another date`` () =
+    let input = DateTime(1959, 7, 19)
+    Assert.That(gigasecond input, Is.EqualTo(DateTime(1991, 3, 27)))

--- a/exercises/grade-school/Example.fs
+++ b/exercises/grade-school/Example.fs
@@ -1,10 +1,15 @@
 ﻿module School
 
-type School() =
+let empty = Map.empty<int, string list>
 
-    let mutable rosterMap : Map<int, string list> = Map.empty
+let add student grade school = 
+    match Map.tryFind grade school with
+    | Some existing -> Map.add grade (student :: existing |> List.sort) school
+    | None -> Map.add grade [student] school
 
-    member this.roster = rosterMap
-    member this.grade(mark:int) = if this.roster.ContainsKey(mark) then this.roster.[mark] else []
-    member this.add(student:string, mark:int): unit = 
-        rosterMap <- Map.add mark (student :: this.grade mark |> List.sort) rosterMap
+let roster school = school |> Map.toSeq
+
+let grade number school = 
+    match Map.tryFind number school with
+    | Some students -> students
+    | None -> []

--- a/exercises/grade-school/GradeSchoolTests.fs
+++ b/exercises/grade-school/GradeSchoolTests.fs
@@ -3,63 +3,69 @@ module GradeSchoolTests
 open NUnit.Framework
 open School
 
-type GradeSchoolTests() = 
-    [<Test>]
-    member tests.New_school_has_an_empty_roster() =
-        let school = new School()
-        Assert.That(school.roster, Has.Count.EqualTo(0))
+[<Test>]
+let ``Empty school has an empty roster`` () =
+    let school = empty
+    Assert.That(roster school, Is.Empty)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.adding_a_student_adds_them_to_the_roster_for_the_given_grade() =
-        let school = new School()
-        school.add("Aimee", 2) |> ignore
-        let expected = ["Aimee"]
-        Assert.That(school.roster.[2], Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Adding a student adds them to the roster for the given grade`` () =
+    let school = empty |> add "Aimee" 2
+    let expected = ["Aimee"]
+    Assert.That(grade 2 school, Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.adding_more_students_to_the_same_grade_adds_them_to_the_roster() =
-        let school = new School()
-        school.add("Blair", 2) |> ignore
-        school.add("James", 2) |> ignore
-        school.add("Paul", 2) |> ignore
-        let expected = ["Blair"; "James"; "Paul"]
-        Assert.That(school.roster.[2], Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Adding more students to the same grade adds them to the roster`` () =
+    let school = 
+        empty
+        |> add "Blair" 2
+        |> add "James" 2
+        |> add "Paul" 2
+    let expected = ["Blair"; "James"; "Paul"]
+    Assert.That(grade 2 school, Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.adding_students_to_different_grades_adds_them_to_the_roster() =
-        let school = new School()
-        school.add("Chelsea", 3) |> ignore
-        school.add("Logan", 7) |> ignore
-        Assert.That(school.roster.[3], Is.EqualTo(["Chelsea"]))
-        Assert.That(school.roster.[7], Is.EqualTo(["Logan"]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Adding students to different grades adds them to the roster`` () =
+    let school = 
+        empty
+        |> add "Chelsea" 3
+        |> add "Logan" 7
+    Assert.That(grade 3 school, Is.EqualTo(["Chelsea"]))
+    Assert.That(grade 7 school, Is.EqualTo(["Logan"]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Grade_returns_the_students_in_that_grade_in_alphabetical_order() =
-        let school = new School()
-        school.add("Franklin", 5) |> ignore
-        school.add("Bradley", 5) |> ignore
-        school.add("Jeff", 1) |> ignore
-        let expected = ["Bradley"; "Franklin"]
-        Assert.That(school.grade(5), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Grade returns the students in that grade in alphabetical order`` () =
+    let school = 
+        empty
+        |> add "Franklin" 5
+        |> add "Bradley" 5
+        |> add "Jeff" 1
+    let expected = ["Bradley"; "Franklin"]
+    Assert.That(grade 5 school, Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Grade_returns_an_empty_list_if_there_are_no_students_in_that_grade() =
-        let school = new School()
-        Assert.That(school.grade(1), Is.EqualTo([]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Grade returns an empty list if there are no students in that grade`` () =
+    let school = empty
+    Assert.That(grade 1 school, Is.EqualTo([]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Student_names_in_each_grade_in_roster_are_sorted() =
-        let school = new School()
-        school.add("Jennifer", 4) |> ignore
-        school.add("Kareem", 6) |> ignore
-        school.add("Christopher", 4) |> ignore
-        school.add("Kyle", 3) |> ignore
-        Assert.That(school.roster.[3], Is.EqualTo(["Kyle"]));
-        Assert.That(school.roster.[4], Is.EqualTo(["Christopher"; "Jennifer"]));
-        Assert.That(school.roster.[6], Is.EqualTo(["Kareem"]));
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Student names and grades in roster are sorted`` () =
+    let school =
+        empty        
+        |> add "Jennifer" 4
+        |> add "Kareem" 6
+        |> add "Christopher" 4
+        |> add "Kyle" 3
+
+    let expected = 
+        [(3, ["Kyle"]);
+         (4, ["Christopher"; "Jennifer"]);
+         (6, ["Kareem"])]
+
+    Assert.That(roster school, Is.EqualTo(expected))

--- a/exercises/grains/Example.fs
+++ b/exercises/grains/Example.fs
@@ -1,8 +1,6 @@
 ﻿module Grains
 
-type Grains() =
-    member this.square(number: int) =
-        2I ** (number - 1)
+open System.Numerics
 
-    member this.total() =
-        [1I..64I] |> List.reduce(fun accumulator element -> accumulator + this.square(int element))
+let square (n:int) = 2I ** (n - 1)
+let total = [1..64] |> List.sumBy square

--- a/exercises/grains/GrainsTest.fs
+++ b/exercises/grains/GrainsTest.fs
@@ -2,45 +2,42 @@
 
 open NUnit.Framework
 open Grains
-
-type GrainsTest() =
-    let grains = Grains()
-
-    [<Test>]
-    member tests.Test_square_1() =
-        Assert.That(grains.square(1), Is.EqualTo(1I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_2() =
-        Assert.That(grains.square(2), Is.EqualTo(2I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_3() =
-        Assert.That(grains.square(3), Is.EqualTo(4I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_4() =
-        Assert.That(grains.square(4), Is.EqualTo(8I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_16() =
-        Assert.That(grains.square(16), Is.EqualTo(32768I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_32() =
-        Assert.That(grains.square(32), Is.EqualTo(2147483648I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_square_64() =
-        Assert.That(grains.square(64), Is.EqualTo(9223372036854775808I))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Test_total_grains() =
-        Assert.That(grains.total(), Is.EqualTo(18446744073709551615I))
+    
+[<Test>]
+let ``Test square 1`` () = 
+    Assert.That(square 1, Is.EqualTo(1I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 2`` () = 
+    Assert.That(square 2, Is.EqualTo(2I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 3`` () = 
+    Assert.That(square 3, Is.EqualTo(4I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 4`` () = 
+    Assert.That(square 4, Is.EqualTo(8I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 16`` () = 
+    Assert.That(square 16, Is.EqualTo(32768I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 32`` () = 
+    Assert.That(square 32, Is.EqualTo(2147483648I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test square 64`` () = 
+    Assert.That(square 64, Is.EqualTo(9223372036854775808I))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Test total grains`` () = 
+    Assert.That(total, Is.EqualTo(18446744073709551615I))

--- a/exercises/hamming/Example.fs
+++ b/exercises/hamming/Example.fs
@@ -1,7 +1,6 @@
 ﻿module Hamming
 
-type Hamming() =
-    member this.compute(strand1:string, strand2:string) = 
-        Array.zip (strand1.ToCharArray()) (strand2.ToCharArray()) |> 
-        Array.filter (fun (c1, c2) -> c1 <> c2) |>
-        Array.length
+let compute (strand1:string) (strand2:string) = 
+    Array.zip (strand1.ToCharArray()) (strand2.ToCharArray()) 
+    |> Array.filter (fun (c1, c2) -> c1 <> c2) 
+    |> Array.length

--- a/exercises/hamming/HammingTests.fs
+++ b/exercises/hamming/HammingTests.fs
@@ -3,33 +3,31 @@
 open NUnit.Framework
 open Hamming
 
-type HammingTests() =
+[<Test>]
+let ``No difference between empty strands`` () =
+    Assert.That(compute "" "", Is.EqualTo(0))
 
-    [<Test>]
-    member tests.No_difference_between_empty_strands() =
-        Assert.That(Hamming().compute("",""), Is.EqualTo(0))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``No difference between identical strands`` () =
+    Assert.That(compute "GGACTGA" "GGACTGA", Is.EqualTo(0))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.No_difference_between_identical_strands() =
-        Assert.That(Hamming().compute("GGACTGA","GGACTGA"), Is.EqualTo(0))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Complete hamming distance in small strand`` () =
+    Assert.That(compute "ACT" "GGA", Is.EqualTo(3))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Complete_hamming_distance_in_small_strand() =
-        Assert.That(Hamming().compute("ACT","GGA"), Is.EqualTo(3))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Hamming distance is off by one strand`` () =
+    Assert.That(compute "GGACGGATTCTG" "AGGACGGATTCT", Is.EqualTo(9))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Hamming_distance_is_off_by_one_strand() =
-        Assert.That(Hamming().compute("GGACGGATTCTG","AGGACGGATTCT"), Is.EqualTo(9))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Smalling hamming distance in middle somewhere`` () =
+    Assert.That(compute "GGACG" "GGTCG", Is.EqualTo(1))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Smalling_hamming_distance_in_middle_somewhere() =
-        Assert.That(Hamming().compute("GGACG","GGTCG"), Is.EqualTo(1))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Larger_distance() =
-        Assert.That(Hamming().compute("ACCAGGG","ACTATGG"), Is.EqualTo(2))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Larger distance`` () =
+    Assert.That(compute "ACCAGGG" "ACTATGG", Is.EqualTo(2))

--- a/exercises/hexadecimal/HexadecimalTest.fs
+++ b/exercises/hexadecimal/HexadecimalTest.fs
@@ -3,22 +3,20 @@ module HexadecimalTests
 open NUnit.Framework
 open Hexadecimal
 
-type HexadecimalTests() =
-
-    [<TestCase("1", ExpectedResult = 1)>]
-    [<TestCase("c", ExpectedResult = 12, Ignore = "Remove to run test case")>]
-    [<TestCase("10", ExpectedResult = 16, Ignore = "Remove to run test case")>]
-    [<TestCase("af", ExpectedResult = 175, Ignore = "Remove to run test case")>]
-    [<TestCase("100", ExpectedResult = 256, Ignore = "Remove to run test case")>]
-    [<TestCase("19ace", ExpectedResult = 105166, Ignore = "Remove to run test case")>]
-    [<TestCase("19ace", ExpectedResult = 105166, Ignore = "Remove to run test case")>]
-    [<TestCase("000000", ExpectedResult = 0, Ignore = "Remove to run test case")>]
-    [<TestCase("ffffff", ExpectedResult = 16777215, Ignore = "Remove to run test case")>]
-    [<TestCase("ffff00", ExpectedResult = 16776960, Ignore = "Remove to run test case")>]
-    member test.Hexadecimal_converts_to_decimal(hexadecimal) =
-        toDecimal(hexadecimal)
+[<TestCase("1", ExpectedResult = 1)>]
+[<TestCase("c", ExpectedResult = 12, Ignore = "Remove to run test case")>]
+[<TestCase("10", ExpectedResult = 16, Ignore = "Remove to run test case")>]
+[<TestCase("af", ExpectedResult = 175, Ignore = "Remove to run test case")>]
+[<TestCase("100", ExpectedResult = 256, Ignore = "Remove to run test case")>]
+[<TestCase("19ace", ExpectedResult = 105166, Ignore = "Remove to run test case")>]
+[<TestCase("19ace", ExpectedResult = 105166, Ignore = "Remove to run test case")>]
+[<TestCase("000000", ExpectedResult = 0, Ignore = "Remove to run test case")>]
+[<TestCase("ffffff", ExpectedResult = 16777215, Ignore = "Remove to run test case")>]
+[<TestCase("ffff00", ExpectedResult = 16776960, Ignore = "Remove to run test case")>]
+let ``Hexadecimal_converts_to_decimal`` hexadecimal =
+    toDecimal hexadecimal
     
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member test.Invalid_hexadecimal_is_decimal_0() =
-        Assert.That(toDecimal("carrot"), Is.EqualTo(0))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Invalid_hexadecimal_is_decimal_0`` () =
+    Assert.That(toDecimal "carrot", Is.EqualTo(0))

--- a/exercises/kindergarten-garden/KinderGartenGardenTest.fs
+++ b/exercises/kindergarten-garden/KinderGartenGardenTest.fs
@@ -3,55 +3,53 @@
 open NUnit.Framework
 open KinderGartenGarden
 
-type KinderGartenGardenTest() =
+[<Test>]
+let ``Missing child`` () =
+    let garden = defaultGarden "RC\nGG"
+    let actual = lookupPlants "Potter" garden
+    Assert.That(actual, Is.Empty)
 
-    [<Test>]
-    member tests.Missing_child() =
-        let garden = defaultGarden "RC\nGG"
-        let actual = lookupPlants "Potter" garden
-        Assert.That(actual, Is.Empty)
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Alice() =
-        Assert.That(defaultGarden "RC\nGG" |> lookupPlants "Alice", Is.EqualTo([Plant.Radishes; Plant.Clover; Plant.Grass; Plant.Grass]))
-        Assert.That(defaultGarden "VC\nRC" |> lookupPlants "Alice", Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Clover]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Alice`` () =
+    Assert.That(defaultGarden "RC\nGG" |> lookupPlants "Alice", Is.EqualTo([Plant.Radishes; Plant.Clover; Plant.Grass; Plant.Grass]))
+    Assert.That(defaultGarden "VC\nRC" |> lookupPlants "Alice", Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Clover]))
     
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Small_garden() =
-        let garden = defaultGarden "VVCG\nVVRC"
-        Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Clover]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Small garden`` () =
+    let garden = defaultGarden "VVCG\nVVRC"
+    Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Clover]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Medium_garden() =
-        let garden = defaultGarden "VVCCGG\nVVCCGG"
-        Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Clover; Plant.Clover; Plant.Clover]))
-        Assert.That(lookupPlants "Charlie" garden, Is.EqualTo([Plant.Grass; Plant.Grass; Plant.Grass; Plant.Grass]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Medium garden`` () =
+    let garden = defaultGarden "VVCCGG\nVVCCGG"
+    Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Clover; Plant.Clover; Plant.Clover]))
+    Assert.That(lookupPlants "Charlie" garden, Is.EqualTo([Plant.Grass; Plant.Grass; Plant.Grass; Plant.Grass]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Full_garden() =
-        let garden = defaultGarden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
-        Assert.That(lookupPlants "Alice" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]))
-        Assert.That(lookupPlants "Alice" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]))
-        Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Clover; Plant.Clover]))
-        Assert.That(lookupPlants "David" garden, Is.EqualTo([Plant.Radishes; Plant.Violets; Plant.Clover; Plant.Radishes]))
-        Assert.That(lookupPlants "Eve" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Grass]))
-        Assert.That(lookupPlants "Fred" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Violets; Plant.Clover]))
-        Assert.That(lookupPlants "Ginny" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Grass; Plant.Clover]))
-        Assert.That(lookupPlants "Harriet" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Radishes; Plant.Violets]))
-        Assert.That(lookupPlants "Ileana" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Violets; Plant.Clover]))
-        Assert.That(lookupPlants "Joseph" garden, Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Violets; Plant.Grass]))
-        Assert.That(lookupPlants "Kincaid" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Clover; Plant.Grass]))
-        Assert.That(lookupPlants "Larry" garden, Is.EqualTo([Plant.Grass; Plant.Violets; Plant.Clover; Plant.Violets]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Full garden`` () =
+    let garden = defaultGarden "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
+    Assert.That(lookupPlants "Alice" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]))
+    Assert.That(lookupPlants "Alice" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Violets; Plant.Radishes]))
+    Assert.That(lookupPlants "Bob" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Clover; Plant.Clover]))
+    Assert.That(lookupPlants "David" garden, Is.EqualTo([Plant.Radishes; Plant.Violets; Plant.Clover; Plant.Radishes]))
+    Assert.That(lookupPlants "Eve" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Radishes; Plant.Grass]))
+    Assert.That(lookupPlants "Fred" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Violets; Plant.Clover]))
+    Assert.That(lookupPlants "Ginny" garden, Is.EqualTo([Plant.Clover; Plant.Grass; Plant.Grass; Plant.Clover]))
+    Assert.That(lookupPlants "Harriet" garden, Is.EqualTo([Plant.Violets; Plant.Radishes; Plant.Radishes; Plant.Violets]))
+    Assert.That(lookupPlants "Ileana" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Violets; Plant.Clover]))
+    Assert.That(lookupPlants "Joseph" garden, Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Violets; Plant.Grass]))
+    Assert.That(lookupPlants "Kincaid" garden, Is.EqualTo([Plant.Grass; Plant.Clover; Plant.Clover; Plant.Grass]))
+    Assert.That(lookupPlants "Larry" garden, Is.EqualTo([Plant.Grass; Plant.Violets; Plant.Clover; Plant.Violets]))
     
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Surprise_garden() =
-        let garden = garden ["Samantha"; "Patricia"; "Xander"; "Roger"] "VCRRGVRG\nRVGCCGCV"
-        Assert.That(lookupPlants "Patricia" garden, Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Violets]))
-        Assert.That(lookupPlants "Roger" garden, Is.EqualTo([Plant.Radishes; Plant.Radishes; Plant.Grass; Plant.Clover]))
-        Assert.That(lookupPlants "Samantha" garden, Is.EqualTo([Plant.Grass; Plant.Violets; Plant.Clover; Plant.Grass]))
-        Assert.That(lookupPlants "Xander" garden, Is.EqualTo([Plant.Radishes; Plant.Grass; Plant.Clover; Plant.Violets]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Surprise garden`` () =
+    let garden = garden ["Samantha"; "Patricia"; "Xander"; "Roger"] "VCRRGVRG\nRVGCCGCV"
+    Assert.That(lookupPlants "Patricia" garden, Is.EqualTo([Plant.Violets; Plant.Clover; Plant.Radishes; Plant.Violets]))
+    Assert.That(lookupPlants "Roger" garden, Is.EqualTo([Plant.Radishes; Plant.Radishes; Plant.Grass; Plant.Clover]))
+    Assert.That(lookupPlants "Samantha" garden, Is.EqualTo([Plant.Grass; Plant.Violets; Plant.Clover; Plant.Grass]))
+    Assert.That(lookupPlants "Xander" garden, Is.EqualTo([Plant.Radishes; Plant.Grass; Plant.Clover; Plant.Violets]))

--- a/exercises/largest-series-product/LargestSeriesProductTest.fs
+++ b/exercises/largest-series-product/LargestSeriesProductTest.fs
@@ -10,12 +10,12 @@ let ``Gets the largest product``(digits: string) (seriesLength: int) =
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Largest product works for small numbers``() =
+let ``Largest product works for small numbers`` () =
     Assert.That(largestProduct "19" 2, Is.EqualTo(9))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Largest product works for large numbers``() =
+let ``Largest product works for large numbers`` () =
     let LARGE_NUMBER = "73167176531330624919225119674426574742355349194934"
     Assert.That(largestProduct LARGE_NUMBER 6, Is.EqualTo(23520))
     
@@ -24,12 +24,12 @@ let ``Largest product works for large numbers``() =
 let ``Largest product works if all spans contain zero``(digits: string) (seriesLength: int) =
     largestProduct digits seriesLength
     
-[<TestCase("", ExpectedResult = 1, Ignore = "Remove to run test case")>]
-[<TestCase("123", ExpectedResult = 1, Ignore = "Remove to run test case")>]
+[<TestCase("", ExpectedResult = 1)>]
+[<TestCase("123", ExpectedResult = 1)>]
 let ``Largest product for empty span is 1``(digits: string) =
     largestProduct digits 0
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cannot slice empty string with nonzero span``() =
-    Assert.Throws(fun () -> largestProduct "" 1 |> ignore) |> ignore
+let ``Cannot slice empty string with nonzero span`` () =
+    Assert.That((fun () -> largestProduct "" 1 |> ignore), Throws.Exception)

--- a/exercises/leap/Example.fs
+++ b/exercises/leap/Example.fs
@@ -1,12 +1,3 @@
 ﻿module LeapYear
 
-[<AbstractClass; Sealed>]
-type LeapYear() =
-    static member isLeap year =
-        match year with
-        | y when y % 100 = 0 -> 
-            match y % 400 = 0 with
-            | true -> true
-            | _ -> false
-        | y when y % 4 = 0 -> true
-        | _ -> false
+let isLeapYear (year: int) = year % 4 = 0 && (year % 400 = 0 || year % 100 <> 0)

--- a/exercises/leap/LeapYearTests.fs
+++ b/exercises/leap/LeapYearTests.fs
@@ -2,24 +2,22 @@
 
 open NUnit.Framework
 open LeapYear
-
-type LeapYearTests() =
-
-    [<Test>]
-    member x.``Is 1996 a valid leap year``() =
-        Assert.That(LeapYear.isLeap 1996, Is.True)
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member x.``Is 1997 an invalid leap year``() =
-        Assert.That(LeapYear.isLeap 1997, Is.False)
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member x.``Is the turn of the 20th century an invalid leap year``() =
-        Assert.That(LeapYear.isLeap 1900, Is.False)
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member x.``Is the turn of the 25th century a valid leap year``() =
-        Assert.That(LeapYear.isLeap 2400, Is.True)
+    
+[<Test>]
+let ``Is 1996 a valid leap year`` () = 
+    Assert.That(isLeapYear 1996, Is.True)
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Is 1997 an invalid leap year`` () = 
+    Assert.That(isLeapYear 1997, Is.False)
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Is the turn of the 20th century an invalid leap year`` () = 
+    Assert.That(isLeapYear 1900, Is.False)
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Is the turn of the 25th century a valid leap year`` () = 
+    Assert.That(isLeapYear 2400, Is.True)

--- a/exercises/linked-list/LinkedListTests.fs
+++ b/exercises/linked-list/LinkedListTests.fs
@@ -3,78 +3,76 @@ module DequeTests
 open NUnit.Framework
 open Deque
 
-type DequeTests() =
+[<Test>]
+let ``Push and pop are first in last out order`` () =
+    let deque = new Deque<int>()
+    deque.push(10)
+    deque.push(20)
+    Assert.That(deque.pop(), Is.EqualTo(20))
+    Assert.That(deque.pop(), Is.EqualTo(10))
 
-    [<Test>]
-    member tests.push_and_pop_are_first_in_last_out_order() =
-        let deque = new Deque<int>()
-        deque.push(10)
-        deque.push(20)
-        Assert.That(deque.pop(), Is.EqualTo(20))
-        Assert.That(deque.pop(), Is.EqualTo(10))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Push and shift are first in first out order`` () =
+    let deque = new Deque<int>()
+    deque.push(10)
+    deque.push(20)
+    Assert.That(deque.shift(), Is.EqualTo(10))
+    Assert.That(deque.shift(), Is.EqualTo(20))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.push_and_shift_are_first_in_first_out_order() =
-        let deque = new Deque<int>()
-        deque.push(10)
-        deque.push(20)
-        Assert.That(deque.shift(), Is.EqualTo(10))
-        Assert.That(deque.shift(), Is.EqualTo(20))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Unshift and shift are last in first out order`` () =
+    let deque = new Deque<int>()
+    deque.unshift(10)
+    deque.unshift(20)
+    Assert.That(deque.shift(), Is.EqualTo(20))
+    Assert.That(deque.shift(), Is.EqualTo(10))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.unshift_and_shift_are_last_in_first_out_order() =
-        let deque = new Deque<int>()
-        deque.unshift(10)
-        deque.unshift(20)
-        Assert.That(deque.shift(), Is.EqualTo(20))
-        Assert.That(deque.shift(), Is.EqualTo(10))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Unshift and pop are last in last out order`` () =
+    let deque = new Deque<int>()
+    deque.unshift(10)
+    deque.unshift(20)
+    Assert.That(deque.pop(), Is.EqualTo(10))
+    Assert.That(deque.pop(), Is.EqualTo(20))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.unshift_and_pop_are_last_in_last_out_order() =
-        let deque = new Deque<int>()
-        deque.unshift(10)
-        deque.unshift(20)
-        Assert.That(deque.pop(), Is.EqualTo(10))
-        Assert.That(deque.pop(), Is.EqualTo(20))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Push and pop can handle multiple values`` () =
+    let deque = new Deque<int>()
+    deque.push(10)
+    deque.push(20)
+    deque.push(30)
+    Assert.That(deque.pop(), Is.EqualTo(30))
+    Assert.That(deque.pop(), Is.EqualTo(20))
+    Assert.That(deque.pop(), Is.EqualTo(10))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.push_and_pop_can_handle_multiple_values() =
-        let deque = new Deque<int>()
-        deque.push(10)
-        deque.push(20)
-        deque.push(30)
-        Assert.That(deque.pop(), Is.EqualTo(30))
-        Assert.That(deque.pop(), Is.EqualTo(20))
-        Assert.That(deque.pop(), Is.EqualTo(10))
+[<Test>]
+[<Ignore("Remove to run test")>]    
+let ``Unshift and shift can handle multiple values`` () =
+    let deque = new Deque<int>()
+    deque.unshift(10)
+    deque.unshift(20)
+    deque.unshift(30)
+    Assert.That(deque.shift(), Is.EqualTo(30))
+    Assert.That(deque.shift(), Is.EqualTo(20))
+    Assert.That(deque.shift(), Is.EqualTo(10))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.unshift_and_shift_can_handle_multiple_values() =
-        let deque = new Deque<int>()
-        deque.unshift(10)
-        deque.unshift(20)
-        deque.unshift(30)
-        Assert.That(deque.shift(), Is.EqualTo(30))
-        Assert.That(deque.shift(), Is.EqualTo(20))
-        Assert.That(deque.shift(), Is.EqualTo(10))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``All methods of manipulating the deque can be used together`` () =
+    let deque = new Deque<int>()
+    deque.push(10)
+    deque.push(20)
+    Assert.That(deque.pop(), Is.EqualTo(20))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.All_methods_of_manipulating_the_deque_can_be_used_together() =
-        let deque = new Deque<int>()
-        deque.push(10)
-        deque.push(20)
-        Assert.That(deque.pop(), Is.EqualTo(20))
+    deque.push(30)
+    Assert.That(deque.shift(), Is.EqualTo(10))
 
-        deque.push(30)
-        Assert.That(deque.shift(), Is.EqualTo(10))
-
-        deque.unshift(40)
-        deque.push(50)
-        Assert.That(deque.shift(), Is.EqualTo(40))
-        Assert.That(deque.pop(), Is.EqualTo(50))
-        Assert.That(deque.shift(), Is.EqualTo(30))
+    deque.unshift(40)
+    deque.push(50)
+    Assert.That(deque.shift(), Is.EqualTo(40))
+    Assert.That(deque.pop(), Is.EqualTo(50))
+    Assert.That(deque.shift(), Is.EqualTo(30))

--- a/exercises/luhn/Example.fs
+++ b/exercises/luhn/Example.fs
@@ -1,23 +1,29 @@
 ﻿module Luhn
-
-type Luhn(number:int64) =
         
-    let digit c = (int)c - (int)'0'
-    let digits = number.ToString() |> Seq.map digit
+let digit c = (int)c - (int)'0'
+let digits number = number.ToString() |> Seq.map digit
 
-    let addend index digit = 
-        if (index % 2 = 0) then digit else 
-        if (digit >= 5) then digit * 2 - 9 
-        else digit * 2
+let addend index digit = 
+    if (index % 2 = 0) then digit else 
+    if (digit >= 5) then digit * 2 - 9 
+    else digit * 2
 
-    member this.checkDigit = number % 10L
-    member this.addends = digits |> List.ofSeq |> List.rev |> List.mapi addend |> List.rev
-    member this.checksum = (this.addends |> List.sum) % 10
-    member this.valid = this.checksum = 0
+let checkDigit (number:int64) = number % 10L
 
-    static member create(target:int64) = 
-        let targetNumber = target * 10L
-        let targetLuhn = Luhn(targetNumber)
+let addends (number:int64) = 
+    number 
+    |> digits 
+    |> List.ofSeq 
+    |> List.rev 
+    |> List.mapi addend 
+    |> List.rev
 
-        if targetLuhn.valid then targetNumber
-        else targetNumber + 10L - (int64)targetLuhn.checksum
+let checksum (number:int64) = (number |> addends |> List.sum) % 10
+
+let valid (number:int64) = checksum number = 0
+
+let create (target:int64) = 
+    let targetNumber = target * 10L
+
+    if valid targetNumber then targetNumber
+    else targetNumber + 10L - (int64)(checksum targetNumber)

--- a/exercises/luhn/LuhnTests.fs
+++ b/exercises/luhn/LuhnTests.fs
@@ -2,43 +2,42 @@ module LuhnTests
 
 open NUnit.Framework
 open Luhn
+  
+[<Test>]
+let ``Check digit is the rightmost digit`` () =
+    Assert.That(checkDigit 34567L, Is.EqualTo 7)
 
-type LuhnTests() =    
-    [<Test>]
-    member tests.Check_digit_is_the_rightmost_digit() =
-        Assert.That(Luhn(34567L).checkDigit, Is.EqualTo(7))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Addends doubles every other number from the right`` () =
+    Assert.That(addends 12121L, Is.EqualTo [1; 4; 1; 4; 1])
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Addends_doubles_every_other_number_from_the_right() =
-        Assert.That(Luhn(12121L).addends, Is.EqualTo([1; 4; 1; 4; 1]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Addends subtracts 9 when doubled number is more than 9`` () =
+    Assert.That(addends 8631L, Is.EqualTo [7; 6; 6; 1])
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Addends_subtracts_9_when_doubled_number_is_more_than_9() =
-        Assert.That(Luhn(8631L).addends, Is.EqualTo([7; 6; 6; 1]))
+[<TestCase(4913, ExpectedResult = 2)>]
+[<TestCase(201773, ExpectedResult = 1)>]
+let ``Checksum adds addends together`` (number) =
+    checksum number
 
-    [<TestCase(4913, ExpectedResult = 2, Ignore = "Remove to run test case")>]
-    [<TestCase(201773, ExpectedResult = 1, Ignore = "Remove to run test case")>]
-    member tests.Checksum_adds_addends_together(number) =
-        Luhn(number).checksum
+[<TestCase(738, ExpectedResult = false)>]
+[<TestCase(8739567, ExpectedResult = true)>]
+let ``Number is valid when checksum mod 10 is zero`` (number) =
+    valid number
 
-    [<TestCase(738, ExpectedResult = false, Ignore = "Remove to run test case")>]
-    [<TestCase(8739567, ExpectedResult = true, Ignore = "Remove to run test case")>]
-    member tests.Number_is_valid_when_checksum_mod_10_is_zero(number) =
-        Luhn(number).valid
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Luhn can create simple numbers with valid check digit`` () =
+    Assert.That(create 123L, Is.EqualTo(1230))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Luhn_can_create_simple_numbers_with_valid_check_digit() =
-        Assert.That(Luhn.create(123L), Is.EqualTo(1230))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Luhn can create larger numbers with valid check digit`` () =
+    Assert.That(create 873956L, Is.EqualTo(8739567))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Luhn_can_create_larger_numbers_with_valid_check_digit() =
-        Assert.That(Luhn.create(873956L), Is.EqualTo(8739567))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Luhn_can_create_huge_numbers_with_valid_check_digit() =
-        Assert.That(Luhn.create(837263756L), Is.EqualTo(8372637564L))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Luhn can create huge numbers with valid check digit`` () =
+    Assert.That(create 837263756L, Is.EqualTo(8372637564L))

--- a/exercises/meetup/MeetupTest.fs
+++ b/exercises/meetup/MeetupTest.fs
@@ -12,7 +12,7 @@ open Meetup
 [<TestCase(4, DayOfWeek.Friday, ExpectedResult = "2013-4-19", Ignore = "Remove to run test case")>]
 [<TestCase(2, DayOfWeek.Saturday, ExpectedResult = "2013-2-16", Ignore = "Remove to run test case")>]
 [<TestCase(10, DayOfWeek.Sunday, ExpectedResult = "2013-10-13", Ignore = "Remove to run test case")>]
-let ``Finds_first_teenth_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds first teenth day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.Teenth 2013 month
     day.ToString("yyyy-M-d")
     
@@ -23,7 +23,7 @@ let ``Finds_first_teenth_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfW
 [<TestCase(11, DayOfWeek.Friday, ExpectedResult = "2013-11-1", Ignore = "Remove to run test case")>]
 [<TestCase(1, DayOfWeek.Saturday, ExpectedResult = "2013-1-5", Ignore = "Remove to run test case")>]
 [<TestCase(4, DayOfWeek.Sunday, ExpectedResult = "2013-4-7", Ignore = "Remove to run test case")>]
-let ``Finds_first_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds first day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.First 2013 month
     day.ToString("yyyy-M-d")
     
@@ -34,7 +34,7 @@ let ``Finds_first_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
 [<TestCase(12, DayOfWeek.Friday, ExpectedResult = "2013-12-13", Ignore = "Remove to run test case")>]
 [<TestCase(2, DayOfWeek.Saturday, ExpectedResult = "2013-2-9", Ignore = "Remove to run test case")>]
 [<TestCase(4, DayOfWeek.Sunday, ExpectedResult = "2013-4-14", Ignore = "Remove to run test case")>]
-let ``Finds_second_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds second day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.Second 2013 month
     day.ToString("yyyy-M-d")
     
@@ -45,7 +45,7 @@ let ``Finds_second_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
 [<TestCase(12, DayOfWeek.Friday, ExpectedResult = "2013-12-20", Ignore = "Remove to run test case")>]
 [<TestCase(2, DayOfWeek.Saturday, ExpectedResult = "2013-2-16", Ignore = "Remove to run test case")>]
 [<TestCase(4, DayOfWeek.Sunday, ExpectedResult = "2013-4-21", Ignore = "Remove to run test case")>]
-let ``Finds_third_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds third day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.Third 2013 month
     day.ToString("yyyy-M-d")
     
@@ -56,7 +56,7 @@ let ``Finds_third_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
 [<TestCase(12, DayOfWeek.Friday, ExpectedResult = "2013-12-27", Ignore = "Remove to run test case")>]
 [<TestCase(2, DayOfWeek.Saturday, ExpectedResult = "2013-2-23", Ignore = "Remove to run test case")>]
 [<TestCase(4, DayOfWeek.Sunday, ExpectedResult = "2013-4-28", Ignore = "Remove to run test case")>]
-let ``Finds_fourth_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds fourth day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.Fourth 2013 month
     day.ToString("yyyy-M-d")
     
@@ -67,6 +67,6 @@ let ``Finds_fourth_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
 [<TestCase(12, DayOfWeek.Friday, ExpectedResult = "2013-12-27", Ignore = "Remove to run test case")>]
 [<TestCase(2, DayOfWeek.Saturday, ExpectedResult = "2013-2-23", Ignore = "Remove to run test case")>]
 [<TestCase(3, DayOfWeek.Sunday, ExpectedResult = "2013-3-31", Ignore = "Remove to run test case")>]
-let ``Finds_last_day_of_week_in_a_month``(month: int) (dayOfWeek: DayOfWeek) =
+let ``Finds last day of week in a month``(month: int) (dayOfWeek: DayOfWeek) =
     let day = meetupDay dayOfWeek Schedule.Last 2013 month
     day.ToString("yyyy-M-d")

--- a/exercises/nucleotide-count/NucleotideCountTest.fs
+++ b/exercises/nucleotide-count/NucleotideCountTest.fs
@@ -5,45 +5,45 @@ open NUnit.Framework
 open NucleoTideCount
 
 [<Test>]
-let ``Has no nucleotides``() =
+let ``Has no nucleotides`` () =
     let strand = ""
     let expected = [ ( 'A', 0 ); ( 'T', 0 ); ( 'C', 0 ); ( 'G', 0 ) ] |> Map.ofSeq
     Assert.That(nucleotideCounts strand, Is.EqualTo(expected))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Has no adenosine``() =
+let ``Has no adenosine`` () =
     let strand = ""
     Assert.That(count 'A' strand, Is.EqualTo(0))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Repetitive cytidine gets counts``() =
+let ``Repetitive cytidine gets counts`` () =
     let strand = "CCCCC"
     Assert.That(count 'C' strand, Is.EqualTo(5))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Repetitive sequence has only guanosine``() =
+let ``Repetitive sequence has only guanosine`` () =
     let strand = "GGGGGGGG"
     let expected = [ ( 'A', 0 ); ( 'T', 0 ); ( 'C', 0 ); ( 'G', 8 ) ] |> Map.ofSeq
     Assert.That(nucleotideCounts strand, Is.EqualTo(expected))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Counts only thymidine``() =
+let ``Counts only thymidine`` () =
     let strand = "GGGGTAACCCGG"
     Assert.That(count 'T' strand, Is.EqualTo(1))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Validates nucleotides``() =
+let ``Validates nucleotides`` () =
     let strand = "GGTTGG"
     Assert.Throws(fun () -> count 'X' strand |> ignore) |> ignore
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Counts all nucleotides``() =
+let ``Counts all nucleotides`` () =
     let strand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
     let expected = [ ( 'A', 20 ); ( 'T', 21 ); ( 'C', 12 ); ( 'G', 17 ) ] |> Map.ofSeq
     Assert.That(nucleotideCounts strand, Is.EqualTo(expected))

--- a/exercises/ocr-numbers/OcrNumbersTest.fs
+++ b/exercises/ocr-numbers/OcrNumbersTest.fs
@@ -5,7 +5,7 @@ open NUnit.Framework
 open OcrNumbers
 
 [<Test>]
-let ``Recognizes zero``() = 
+let ``Recognizes zero`` () = 
     let converted = convert (" _ " + "\n" +
                               "| |" + "\n" +
                               "|_|" + "\n" +
@@ -14,7 +14,7 @@ let ``Recognizes zero``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes one``() = 
+let ``Recognizes one`` () = 
     let converted = convert ("   " + "\n" +
                              "  |" + "\n" +
                              "  |" + "\n" +
@@ -23,7 +23,7 @@ let ``Recognizes one``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes two``() = 
+let ``Recognizes two`` () = 
     let converted = convert (" _ " + "\n" +
                              " _|" + "\n" +
                              "|_ " + "\n" +
@@ -32,7 +32,7 @@ let ``Recognizes two``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes three``() = 
+let ``Recognizes three`` () = 
     let converted = convert (" _ " + "\n" +
                              " _|" + "\n" +
                              " _|" + "\n" +
@@ -41,7 +41,7 @@ let ``Recognizes three``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes four``() = 
+let ``Recognizes four`` () = 
     let converted = convert ("   " + "\n" +
                              "|_|" + "\n" +
                              "  |" + "\n" +
@@ -50,7 +50,7 @@ let ``Recognizes four``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes five``() = 
+let ``Recognizes five`` () = 
     let converted = convert (" _ " + "\n" +
                              "|_ " + "\n" +
                              " _|" + "\n" +
@@ -59,7 +59,7 @@ let ``Recognizes five``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes six``() = 
+let ``Recognizes six`` () = 
     let converted = convert (" _ " + "\n" +
                              "|_ " + "\n" +
                              "|_|" + "\n" +
@@ -68,7 +68,7 @@ let ``Recognizes six``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes seven``() = 
+let ``Recognizes seven`` () = 
     let converted = convert (" _ " + "\n" +
                              "  |" + "\n" +
                              "  |" + "\n" +
@@ -77,7 +77,7 @@ let ``Recognizes seven``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes eight``() = 
+let ``Recognizes eight`` () = 
     let converted = convert (" _ " + "\n" +
                              "|_|" + "\n" +
                              "|_|" + "\n" +
@@ -86,7 +86,7 @@ let ``Recognizes eight``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes nine``() = 
+let ``Recognizes nine`` () = 
     let converted = convert (" _ " + "\n" +
                              "|_|" + "\n" +
                              " _|" + "\n" +
@@ -95,7 +95,7 @@ let ``Recognizes nine``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes garble``() = 
+let ``Recognizes garble`` () = 
     let converted = convert ("   " + "\n" +
                              "| |" + "\n" +
                              "| |" + "\n" +
@@ -104,7 +104,7 @@ let ``Recognizes garble``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes ten``() = 
+let ``Recognizes ten`` () = 
     let converted = convert ("    _ " + "\n" +
                              "  || |" + "\n" +
                              "  ||_|" + "\n" +
@@ -113,7 +113,7 @@ let ``Recognizes ten``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes 110101100``() = 
+let ``Recognizes 110101100`` () = 
     let converted = convert ("       _     _        _  _ " + "\n" +
                              "  |  || |  || |  |  || || |" + "\n" +
                              "  |  ||_|  ||_|  |  ||_||_|" + "\n" +
@@ -122,7 +122,7 @@ let ``Recognizes 110101100``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes numbers and garble``() = 
+let ``Recognizes numbers and garble`` () = 
     let converted = convert ("       _     _           _ " + "\n" +
                              "  |  || |  || |     || || |" + "\n" +
                              "  |  | _|  ||_|  |  ||_||_|" + "\n" +
@@ -131,7 +131,7 @@ let ``Recognizes numbers and garble``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Recognizes multiple rows``() = 
+let ``Recognizes multiple rows`` () = 
     let converted = convert ("    _  _ " + "\n" +
                              "  | _| _|" + "\n" +
                              "  ||_  _|" + "\n" +

--- a/exercises/octal/Example.fs
+++ b/exercises/octal/Example.fs
@@ -1,13 +1,10 @@
 ﻿module Octal
 
-type Octal(input: string) =
-    let rec toDecimalLoop acc input = 
-        if input = "" then acc
-        else 
-            let head = input.Chars 0
-            let tail = input.Substring 1
-            match head with
-                | x when x >= '0' && x <= '7' -> toDecimalLoop (acc * 8 + (int)head - (int)'0') tail
-                | _  -> 0   
+let isValid char = char >= '0' && char <= '7'
 
-    member this.toDecimal() = toDecimalLoop 0 input
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal (input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 8 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/octal/OctalTests.fs
+++ b/exercises/octal/OctalTests.fs
@@ -2,24 +2,22 @@
 
 open NUnit.Framework
 open Octal
-
-type OctalTests() =
     
-    [<TestCase("1", ExpectedResult = 1)>]
-    [<TestCase("10", ExpectedResult = 8, Ignore = "Remove to run test case")>]
-    [<TestCase("17", ExpectedResult = 15, Ignore = "Remove to run test case")>]
-    [<TestCase("11", ExpectedResult = 9, Ignore = "Remove to run test case")>]
-    [<TestCase("130", ExpectedResult = 88, Ignore = "Remove to run test case")>]
-    [<TestCase("2047", ExpectedResult = 1063, Ignore = "Remove to run test case")>]
-    [<TestCase("7777", ExpectedResult = 4095, Ignore = "Remove to run test case")>]
-    [<TestCase("1234567", ExpectedResult = 342391, Ignore = "Remove to run test case")>]
-    member tests.Octal_converts_to_decimal(input) =
-        Octal(input).toDecimal()
+[<TestCase("1", ExpectedResult = 1)>]
+[<TestCase("10", ExpectedResult = 8, Ignore = "Remove to run test case")>]
+[<TestCase("17", ExpectedResult = 15, Ignore = "Remove to run test case")>]
+[<TestCase("11", ExpectedResult = 9, Ignore = "Remove to run test case")>]
+[<TestCase("130", ExpectedResult = 88, Ignore = "Remove to run test case")>]
+[<TestCase("2047", ExpectedResult = 1063, Ignore = "Remove to run test case")>]
+[<TestCase("7777", ExpectedResult = 4095, Ignore = "Remove to run test case")>]
+[<TestCase("1234567", ExpectedResult = 342391, Ignore = "Remove to run test case")>]
+let ``Octal converts to decimal`` (input) =
+    toDecimal input
 
-    [<TestCase("carrot", Ignore = "Remove to run test case")>]
-    [<TestCase("8", Ignore = "Remove to run test case")>]
-    [<TestCase("9", Ignore = "Remove to run test case")>]
-    [<TestCase("6789", Ignore = "Remove to run test case")>]
-    [<TestCase("abc1z", Ignore = "Remove to run test case")>]
-    member tests.Invalid_octal_is_decimal_0(input) =
-        Assert.That(Octal(input).toDecimal(), Is.EqualTo(0))
+[<TestCase("carrot", Ignore = "Remove to run test case")>]
+[<TestCase("8", Ignore = "Remove to run test case")>]
+[<TestCase("9", Ignore = "Remove to run test case")>]
+[<TestCase("6789", Ignore = "Remove to run test case")>]
+[<TestCase("abc1z", Ignore = "Remove to run test case")>]
+let ``Invalid octal is decimal 0`` (input) =
+    Assert.That(toDecimal input, Is.EqualTo(0))

--- a/exercises/palindrome-products/PalindromeTest.fs
+++ b/exercises/palindrome-products/PalindromeTest.fs
@@ -5,56 +5,56 @@ open NUnit.Framework
 open Palindrome
 
 [<Test>]
-let ``Largest palindrome from single digit factors``() =
+let ``Largest palindrome from single digit factors`` () =
     let (largest, factors) = largestPalindrome 1 9
     Assert.That(largest, Is.EqualTo(9))
     Assert.That(factors, Is.EqualTo([(1, 9); (3, 3)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Smallest palindrome from single digit factors``() =
+let ``Smallest palindrome from single digit factors`` () =
     let (smallest, factors) = smallestPalindrome 1 9
     Assert.That(smallest, Is.EqualTo(1))
     Assert.That(factors, Is.EqualTo([(1, 1)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Largest palindrome from double digit actors``() =
+let ``Largest palindrome from double digit actors`` () =
     let (largest, factors) = largestPalindrome 10 99
     Assert.That(largest, Is.EqualTo(9009))
     Assert.That(factors, Is.EqualTo([(91, 99)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Smallest palindrome from double digit factors``() =
+let ``Smallest palindrome from double digit factors`` () =
     let (smallest, factors) = smallestPalindrome 10 99
     Assert.That(smallest, Is.EqualTo(121))
     Assert.That(factors, Is.EqualTo([(11, 11)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Largest palindrome from triple digit factors``() =
+let ``Largest palindrome from triple digit factors`` () =
     let (largest, factors) = largestPalindrome 100 999
     Assert.That(largest, Is.EqualTo(906609))
     Assert.That(factors, Is.EqualTo([(913, 993)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Smallest palindrome from triple digit factors``() =
+let ``Smallest palindrome from triple digit factors`` () =
     let (smallest, factors) = smallestPalindrome 100 999
     Assert.That(smallest, Is.EqualTo(10201))
     Assert.That(factors, Is.EqualTo([(101, 101)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Largest palindrome from four digit factors``() =
+let ``Largest palindrome from four digit factors`` () =
     let (largest, factors) = largestPalindrome 1000 9999
     Assert.That(largest, Is.EqualTo(99000099))
     Assert.That(factors, Is.EqualTo([(9901, 9999)]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Smallest palindrome from four digit factors``() =
+let ``Smallest palindrome from four digit factors`` () =
     let (smallest, factors) = smallestPalindrome 1000 9999
     Assert.That(smallest, Is.EqualTo(1002001))
     Assert.That(factors, Is.EqualTo([(1001, 1001)]))

--- a/exercises/pascals-triangle/PascalsTriangleTest.fs
+++ b/exercises/pascals-triangle/PascalsTriangleTest.fs
@@ -5,30 +5,30 @@ open NUnit.Framework
 open PascalsTriangle
 
 [<Test>]
-let ``One row``() =
+let ``One row`` () =
     Assert.That(triangle 1, Is.EqualTo([[1]]))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Two rows``() =
+let ``Two rows`` () =
     Assert.That(triangle 2, Is.EqualTo([[1]; [1; 1]]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Three rows``() =
+let ``Three rows`` () =
     Assert.That(triangle 3, Is.EqualTo([[1]; [1; 1]; [1; 2; 1]]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Four rows``() =
+let ``Four rows`` () =
     Assert.That(triangle 4, Is.EqualTo([[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Five rows``() =
+let ``Five rows`` () =
     Assert.That(triangle 5, Is.EqualTo([[1]; [1; 1]; [1; 2; 1]; [1; 3; 3; 1]; [1; 4; 6; 4; 1]]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Twenty rows``() =
+let ``Twenty rows`` () =
     Assert.That(triangle 20 |> List.last, Is.EqualTo([1; 19; 171; 969; 3876; 11628; 27132; 50388; 75582; 92378; 92378; 75582; 50388; 27132; 11628; 3876; 969; 171; 19; 1]))

--- a/exercises/pig-latin/Example.fs
+++ b/exercises/pig-latin/Example.fs
@@ -2,13 +2,12 @@
 
 open System.Text.RegularExpressions
 
-type PigLatin() =
-    let vowelRegex = Regex(@"(?<begin>^|\s+)(?<vowel>a|e|i|o|u|yt|xr)(?<rest>\w+)", RegexOptions.Compiled)
-    let consonantRegex = Regex(@"(?<begin>^|\s+)(?<consonant>ch|qu|thr|th|sch|yt|\wqu|\w)(?<rest>\w+)", RegexOptions.Compiled)
+let vowelRegex = Regex(@"(?<begin>^|\s+)(?<vowel>a|e|i|o|u|yt|xr)(?<rest>\w+)", RegexOptions.Compiled)
+let consonantRegex = Regex(@"(?<begin>^|\s+)(?<consonant>ch|qu|thr|th|sch|yt|\wqu|\w)(?<rest>\w+)", RegexOptions.Compiled)
 
-    let vowelReplacement = "${begin}${vowel}${rest}ay";
-    let consonantReplacement = "${begin}${rest}${consonant}ay";
+let vowelReplacement = "${begin}${vowel}${rest}ay";
+let consonantReplacement = "${begin}${rest}${consonant}ay";
 
-    member this.translate(input) = 
-        if vowelRegex.IsMatch input then vowelRegex.Replace(input, vowelReplacement)
-        else consonantRegex.Replace(input, consonantReplacement)
+let translate input = 
+    if vowelRegex.IsMatch input then vowelRegex.Replace(input, vowelReplacement)
+    else consonantRegex.Replace(input, consonantReplacement)

--- a/exercises/pig-latin/PigLatinTests.fs
+++ b/exercises/pig-latin/PigLatinTests.fs
@@ -3,64 +3,62 @@
 open NUnit.Framework
 open PigLatin
 
-type PigLatinTests() =
-    
-    [<TestCase("apple", ExpectedResult = "appleay")>]
-    [<TestCase("ear", ExpectedResult = "earay", Ignore = "Remove to run test case")>]
-    [<TestCase("igloo", ExpectedResult = "iglooay", Ignore = "Remove to run test case")>]
-    [<TestCase("object", ExpectedResult = "objectay", Ignore = "Remove to run test case")>]
-    [<TestCase("under", ExpectedResult = "underay", Ignore = "Remove to run test case")>]
-    member tests.Ay_is_added_to_words_that_start_with_vowels(word) =
-        PigLatin().translate(word)
+[<TestCase("apple", ExpectedResult = "appleay")>]
+[<TestCase("ear", ExpectedResult = "earay", Ignore = "Remove to run test case")>]
+[<TestCase("igloo", ExpectedResult = "iglooay", Ignore = "Remove to run test case")>]
+[<TestCase("object", ExpectedResult = "objectay", Ignore = "Remove to run test case")>]
+[<TestCase("under", ExpectedResult = "underay", Ignore = "Remove to run test case")>]
+let ``Ay is added to words that start with vowels`` (word) =
+    translate word
 
-    [<TestCase("pig", ExpectedResult = "igpay", Ignore = "Remove to run test case")>]
-    [<TestCase("koala", ExpectedResult = "oalakay", Ignore = "Remove to run test case")>]
-    [<TestCase("yellow", ExpectedResult = "ellowyay", Ignore = "Remove to run test case")>]
-    [<TestCase("xenon", ExpectedResult = "enonxay", Ignore = "Remove to run test case")>]
-    member tests.First_letter_and_ay_are_moved_to_the_end_of_words_that_start_with_consonants(word) =
-        PigLatin().translate(word)
+[<TestCase("pig", ExpectedResult = "igpay", Ignore = "Remove to run test case")>]
+[<TestCase("koala", ExpectedResult = "oalakay", Ignore = "Remove to run test case")>]
+[<TestCase("yellow", ExpectedResult = "ellowyay", Ignore = "Remove to run test case")>]
+[<TestCase("xenon", ExpectedResult = "enonxay", Ignore = "Remove to run test case")>]
+let ``First letter and ay are moved to the end of words that start with consonants`` (word) =
+    translate word
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Ch_is_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("chair"), Is.EqualTo("airchay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Ch is treated like a single consonant`` () =
+    Assert.That(translate "chair", Is.EqualTo("airchay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Qu_is_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("queen"), Is.EqualTo("eenquay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Qu is treated like a single consonant`` () =
+    Assert.That(translate "queen", Is.EqualTo("eenquay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Qu_and_a_single_preceding_consonant_are_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("square"), Is.EqualTo("aresquay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Qu and a single preceding consonant are treated like a single consonant`` () =
+    Assert.That(translate "square", Is.EqualTo("aresquay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Th_is_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("therapy"), Is.EqualTo("erapythay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Th is treated like a single consonant`` () =
+    Assert.That(translate "therapy", Is.EqualTo("erapythay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Thr_is_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("thrush"), Is.EqualTo("ushthray"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Thr is treated like a single consonant`` () =
+    Assert.That(translate "thrush", Is.EqualTo("ushthray"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Sch_is_treated_like_a_single_consonant() =
-        Assert.That(PigLatin().translate("school"), Is.EqualTo("oolschay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Sch is treated like a single consonant`` () =
+    Assert.That(translate "school", Is.EqualTo("oolschay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Yt_is_treated_like_a_single_vowel() =
-        Assert.That(PigLatin().translate("yttria"), Is.EqualTo("yttriaay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Yt is treated like a single vowel`` () =
+    Assert.That(translate "yttria", Is.EqualTo("yttriaay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Xr_is_treated_like_a_single_vowel() =
-        Assert.That(PigLatin().translate("xray"), Is.EqualTo("xrayay"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Xr is treated like a single vowel`` () =
+    Assert.That(translate "xray", Is.EqualTo("xrayay"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Phrases_are_translated() =
-        Assert.That(PigLatin().translate("quick fast run"), Is.EqualTo("ickquay astfay unray"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Phrases are translated`` () =
+    Assert.That(translate "quick fast run", Is.EqualTo("ickquay astfay unray"))

--- a/exercises/prime-factors/PrimeFactorsTest.fs
+++ b/exercises/prime-factors/PrimeFactorsTest.fs
@@ -5,50 +5,50 @@ open NUnit.Framework
 open PrimeFactors
 
 [<Test>]
-let ``Test 1``() =
+let ``Test 1`` () =
     Assert.That(primeFactorsFor 1L, Is.EqualTo([]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 2``() =
+let ``Test 2`` () =
     Assert.That(primeFactorsFor 2L, Is.EqualTo([2]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 3``() =
+let ``Test 3`` () =
     Assert.That(primeFactorsFor 3L, Is.EqualTo([3]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 4``() =
+let ``Test 4`` () =
     Assert.That(primeFactorsFor 4L, Is.EqualTo([2; 2]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 6``() =
+let ``Test 6`` () =
     Assert.That(primeFactorsFor 6L, Is.EqualTo([2; 3]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 8``() =
+let ``Test 8`` () =
     Assert.That(primeFactorsFor 8L, Is.EqualTo([2; 2; 2]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 9``() =
+let ``Test 9`` () =
     Assert.That(primeFactorsFor 9L, Is.EqualTo([3; 3]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 27``() =
+let ``Test 27`` () =
     Assert.That(primeFactorsFor 27L, Is.EqualTo([3; 3; 3]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 625``() =
+let ``Test 625`` () =
     Assert.That(primeFactorsFor 625L, Is.EqualTo([5; 5; 5; 5]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 901255``() =
+let ``Test 901255`` () =
     Assert.That(primeFactorsFor 901255L, Is.EqualTo([5; 17; 23; 461]))

--- a/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
+++ b/exercises/pythagorean-triplet/PythagoreanTripletTest.fs
@@ -18,18 +18,18 @@ let ``Can recognize a valid pythagorean`` (x: int) (y: int) (z: int) =
    
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can create simple triplets``() =
+let ``Can create simple triplets`` () =
     let actual = pythagoreanTriplets 1 10
     Assert.That(actual, Is.EqualTo([triplet 3 4 5; triplet 6 8 10]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can create more triplets``() =
+let ``Can create more triplets`` () =
     let actual = pythagoreanTriplets 11 20
     Assert.That(actual, Is.EqualTo([triplet 12 16 20]))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can create complex triplets``() =
+let ``Can create complex triplets`` () =
     let actual = pythagoreanTriplets 56 95
     Assert.That(actual, Is.EqualTo([triplet 57 76 95; triplet 60 63 87]))

--- a/exercises/queen-attack/QueenAttackTest.fs
+++ b/exercises/queen-attack/QueenAttackTest.fs
@@ -6,42 +6,42 @@ open NUnit.Framework
 open QueenAttack
 
 [<Test>]
-let ``Cannot occupy same space``() =
+let ``Cannot occupy same space`` () =
     let white = (2, 4)
     let black = (2, 4)
-    Assert.Throws(fun () -> canAttack white black |> ignore) |> ignore
+    Assert.That((fun () -> canAttack white black |> ignore), Throws.Exception)
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cannot attack``() =
+let ``Cannot attack`` () =
     Assert.False(canAttack (2, 3) (4, 7))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on same row``() =
+let ``Can attack on same row`` () =
     Assert.True(canAttack (2, 4) (2, 7))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on same column``() =
+let ``Can attack on same column`` () =
     Assert.True(canAttack (5, 4) (2, 4))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on diagonal``() =
+let ``Can attack on diagonal`` () =
     Assert.True(canAttack (1, 1) (6, 6))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on other diagonal``() =
+let ``Can attack on other diagonal`` () =
     Assert.True(canAttack (0, 6) (1, 7))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on yet another diagonal``() =
+let ``Can attack on yet another diagonal`` () =
     Assert.True(canAttack (4, 1) (6, 3))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can attack on a diagonal slanted the other way``() =
+let ``Can attack on a diagonal slanted the other way`` () =
     Assert.True(canAttack (6, 1) (1, 6))

--- a/exercises/raindrops/Example.fs
+++ b/exercises/raindrops/Example.fs
@@ -3,10 +3,9 @@
 open System
 open System.Globalization
 
-type Raindrops() =
-    member this.convert(number:int) =
-        let factors = [(3, "Pling"); (5, "Plang"); (7, "Plong")]
-        let factorStrings = [for (factor, str) in factors do if number % factor = 0 then yield str]
-        match factorStrings with
-        | [] -> number.ToString(CultureInfo.InvariantCulture)
-        | xs -> String.concat "" xs
+let convert (number:int) =
+    let factors = [(3, "Pling"); (5, "Plang"); (7, "Plong")]
+    let factorStrings = [for (factor, str) in factors do if number % factor = 0 then yield str]
+    match factorStrings with
+    | [] -> number.ToString(CultureInfo.InvariantCulture)
+    | xs -> String.concat "" xs

--- a/exercises/raindrops/RaindropsTests.fs
+++ b/exercises/raindrops/RaindropsTests.fs
@@ -3,35 +3,33 @@ module RaindropsTests
 open NUnit.Framework
 open Raindrops
 
-type RaindropsTests() =
-    [<TestCase(1, ExpectedResult = "1")>]
-    [<TestCase(52, ExpectedResult = "52", Ignore = "Remove to run test case")>]
-    [<TestCase(12121, ExpectedResult = "12121", Ignore = "Remove to run test case")>]
-    member tests.Non_primes_pass_through(number) =
-        Raindrops().convert(number)
+[<TestCase(1, ExpectedResult = "1")>]
+[<TestCase(52, ExpectedResult = "52", Ignore = "Remove to run test case")>]
+[<TestCase(12121, ExpectedResult = "12121", Ignore = "Remove to run test case")>]
+let ``Non primes pass through`` (number) =
+    convert number
 
-    [<TestCase(3, Ignore = "Remove to run test case")>]
-    [<TestCase(6, Ignore = "Remove to run test case")>]
-    [<TestCase(9, Ignore = "Remove to run test case")>]
-    member tests.Numbers_containing_3_as_a_prime_factor_give_pling(number) =
-        Assert.That(Raindrops().convert(number), Is.EqualTo("Pling"))
+[<TestCase(3, Ignore = "Remove to run test case")>]
+[<TestCase(6, Ignore = "Remove to run test case")>]
+[<TestCase(9, Ignore = "Remove to run test case")>]
+let ``Numbers containing 3 as a prime factor give pling`` (number) =
+    Assert.That(convert number, Is.EqualTo("Pling"))
 
-    [<TestCase(5, Ignore = "Remove to run test case")>]
-    [<TestCase(10, Ignore = "Remove to run test case")>]
-    [<TestCase(25, Ignore = "Remove to run test case")>]
-    member tests.Numbers_containing_5_as_a_prime_factor_give_plang(number) =
-        Assert.That(Raindrops().convert(number), Is.EqualTo("Plang"))
+[<TestCase(5, Ignore = "Remove to run test case")>]
+[<TestCase(10, Ignore = "Remove to run test case")>]
+[<TestCase(25, Ignore = "Remove to run test case")>]
+let ``Numbers containing 5 as a prime factor give plang`` (number) =
+    Assert.That(convert number, Is.EqualTo("Plang"))
 
-    [<TestCase(7, Ignore = "Remove to run test case")>]
-    [<TestCase(14, Ignore = "Remove to run test case")>]
-    [<TestCase(49, Ignore = "Remove to run test case")>]
-    member tests.Numbers_containing_7_as_a_prime_factor_give_plong(number) =
-        Assert.That(Raindrops().convert(number), Is.EqualTo("Plong"))
+[<TestCase(7, Ignore = "Remove to run test case")>]
+[<TestCase(14, Ignore = "Remove to run test case")>]
+[<TestCase(49, Ignore = "Remove to run test case")>]
+let ``Numbers containing 7 as a prime factor give plong`` (number) =
+    Assert.That(convert number, Is.EqualTo("Plong"))
 
-    [<TestCase(15, ExpectedResult = "PlingPlang", Ignore = "Remove to run test case")>]
-    [<TestCase(21, ExpectedResult = "PlingPlong", Ignore = "Remove to run test case")>]
-    [<TestCase(35, ExpectedResult = "PlangPlong", Ignore = "Remove to run test case")>]
-    [<TestCase(105, ExpectedResult = "PlingPlangPlong", Ignore = "Remove to run test case")>]
-    [<Ignore("Remove to run test")>]
-    member tests.Numbers_containing_multiple_prime_factors_give_all_results_concatenated(number) =
-        Raindrops().convert(number)
+[<TestCase(15, ExpectedResult = "PlingPlang", Ignore = "Remove to run test case")>]
+[<TestCase(21, ExpectedResult = "PlingPlong", Ignore = "Remove to run test case")>]
+[<TestCase(35, ExpectedResult = "PlangPlong", Ignore = "Remove to run test case")>]
+[<TestCase(105, ExpectedResult = "PlingPlangPlong", Ignore = "Remove to run test case")>]    
+let ``Numbers containing multiple prime factors give all results concatenated`` (number) =
+    convert number

--- a/exercises/rna-transcription/Example.fs
+++ b/exercises/rna-transcription/Example.fs
@@ -1,11 +1,9 @@
 ﻿module Complement
 
-type Complement() =
+let rnaToDna = Map.ofSeq [('G', 'C'); ('C', 'G'); ('U', 'A'); ('A', 'T')]
+let dnaToRna = Map.ofSeq [('G', 'C'); ('C', 'G'); ('T', 'A'); ('A', 'U')]
 
-    let rnaToDna = Map.ofSeq [('G', 'C'); ('C', 'G'); ('U', 'A'); ('A', 'T')]
-    let dnaToRna = Map.ofSeq [('G', 'C'); ('C', 'G'); ('T', 'A'); ('A', 'U')]
+let transpose (input:string) map = new string(input.ToCharArray() |> Array.map (fun c -> Map.find c map))
 
-    let transpose (input:string) map = new string(input.ToCharArray() |> Array.map (fun c -> Map.find c map))
-
-    member this.ofDna(dna:string) = transpose dna dnaToRna
-    member this.ofRna(rna:string) = transpose rna rnaToDna
+let toRna (dna:string) = transpose dna dnaToRna
+let toDna (rna:string) = transpose rna rnaToDna

--- a/exercises/rna-transcription/RNATranscriptionTests.fs
+++ b/exercises/rna-transcription/RNATranscriptionTests.fs
@@ -2,54 +2,52 @@
 
 open NUnit.Framework
 open Complement
-
-type RNATranscriptionTest() =
     
-    [<Test>]
-    member tests.Rna_complement_of_cytosine_is_guanine() =
-        Assert.That(Complement().ofDna("C"), Is.EqualTo("G"))
+[<Test>]
+let ``Rna complement of cytosine is guanine`` () =
+    Assert.That(toRna "C", Is.EqualTo("G"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Rna_complement_of_guanine_is_cytosine() =
-        Assert.That(Complement().ofDna("G"), Is.EqualTo("C"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Rna complement of guanine is cytosine`` () =
+    Assert.That(toRna "G", Is.EqualTo("C"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Rna_complement_of_thymine_is_adenine() =
-        Assert.That(Complement().ofDna("T"), Is.EqualTo("A"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Rna complement of thymine is adenine`` () =
+    Assert.That(toRna "T", Is.EqualTo("A"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Rna_complement_of_adenine_is_uracil() =
-        Assert.That(Complement().ofDna("A"), Is.EqualTo("U"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Rna complement of adenine is uracil`` () =
+    Assert.That(toRna "A", Is.EqualTo("U"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Rna_complement() =
-        Assert.That(Complement().ofDna("ACGTGGTCTTAA"), Is.EqualTo("UGCACCAGAAUU"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Rna complement`` () =
+    Assert.That(toRna "ACGTGGTCTTAA", Is.EqualTo("UGCACCAGAAUU"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Dna_complement_of_cytosine_is_guanine() =
-        Assert.That(Complement().ofRna("C"), Is.EqualTo("G"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Dna complement of cytosine is guanine`` () =
+    Assert.That(toDna "C", Is.EqualTo("G"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Dna_complement_of_guanine_is_cytosine() =
-        Assert.That(Complement().ofRna("G"), Is.EqualTo("C"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Dna complement of guanine is cytosine`` () =
+    Assert.That(toDna "G", Is.EqualTo("C"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Dna_complement_of_uracil_is_adenine() =
-        Assert.That(Complement().ofRna("U"), Is.EqualTo("A"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Dna complement of uracil is adenine`` () =
+    Assert.That(toDna "U", Is.EqualTo("A"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Dna_complement_of_adenine_is_thymine() =
-        Assert.That(Complement().ofRna("A"), Is.EqualTo("T"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Dna complement of adenine is thymine`` () =
+    Assert.That(toDna "A", Is.EqualTo("T"))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Dna_complement() =
-        Assert.That(Complement().ofRna("UGAACCCGACAUG"), Is.EqualTo("ACTTGGGCTGTAC"))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Dna complement`` () =
+    Assert.That(toDna "UGAACCCGACAUG", Is.EqualTo("ACTTGGGCTGTAC"))

--- a/exercises/robot-name/Example.fs
+++ b/exercises/robot-name/Example.fs
@@ -1,22 +1,19 @@
 ﻿module RobotName
 
-type RobotName() =
-    let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    let random = System.Random()
+let random = System.Random()
 
-    let generateRandomChar() = 
-        let index = random.Next(25)
-        alphabet.Substring(index, 1)
+type Robot() =
+    let letters = ['A'..'Z']
+    let digits = ['0'..'9']
 
-    let generateName() =
-        let number = random.Next(100, 999)
-        generateRandomChar() + generateRandomChar() + string number
+    let NumberOfLetters = 2;
+    let NumberOfDigits = 3    
 
-    let mutable name = generateName()
-
-    member this.Name
-        with get() = name
-        and set(value) = name <- value
-
-    member this.Reset() =
-        this.Name <- generateName()
+    let takeRandomElements xs length = List.init length (fun _ -> List.item (random.Next(List.length xs)) xs)
+    let generateRandomString chars length = new System.String(takeRandomElements chars length |> List.toArray)
+    let generateLetters() = generateRandomString letters NumberOfLetters
+    let generateDigits() = generateRandomString digits NumberOfDigits
+    let generateName() = generateLetters() + generateDigits()
+    
+    member val Name = generateName() with get, set
+    member this.Reset() = this.Name <- generateName()

--- a/exercises/robot-name/RobotNameTest.fs
+++ b/exercises/robot-name/RobotNameTest.fs
@@ -3,30 +3,28 @@
 open NUnit.Framework
 open RobotName
 
-type RobotNameTest() =
-    let robot = RobotName()
-
-    [<Test>]
-    member tests.``Robot has a name``() =
-        StringAssert.IsMatch(@"\w{2}\d{3}", robot.Name)
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.``Name is the same each time``() =
-        Assert.That(robot.Name, Is.EqualTo(robot.Name))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member this.``Different robots have different names``() =
-        let robot2 = RobotName()
-
-        Assert.That(robot.Name, Is.Not.EqualTo(robot2.Name))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member this.``Can reset the name``() =
-        let originalName = robot.Name
-        
-        robot.Reset()
-
-        Assert.That(originalName, Is.Not.EqualTo(robot.Name))
+[<Test>]
+let ``Robot has a name`` () =     
+    let robot = new Robot()
+    StringAssert.IsMatch(@"\w{2}\d{3}", robot.Name)
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Name is the same each time`` () =     
+    let robot = new Robot()
+    Assert.That(robot.Name, Is.EqualTo(robot.Name))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Different robots have different names`` () = 
+    let robot = new Robot()
+    let robot2 = new Robot()
+    Assert.That(robot.Name, Is.Not.EqualTo(robot2.Name))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Can reset the name`` () =  
+    let robot = new Robot()
+    let originalName = robot.Name
+    robot.Reset()
+    Assert.That(originalName, Is.Not.EqualTo(robot.Name))

--- a/exercises/roman-numerals/Example.fs
+++ b/exercises/roman-numerals/Example.fs
@@ -1,26 +1,24 @@
 ﻿module RomanNumeral
 
-type RomanNumeral() =
+let numeralThresholds = [(1000, "M");
+                            (900,  "CM");
+                            (500,  "D");
+                            (400,  "CD");
+                            (100,  "C");
+                            (90,   "XC");
+                            (50,   "L");
+                            (40,   "XL");
+                            (10,   "X");
+                            (9,    "IX");
+                            (5,    "V");
+                            (4,    "IV");
+                            (1,    "I")]
 
-    let numeralThresholds = [(1000, "M");
-                             (900,  "CM");
-                             (500,  "D");
-                             (400,  "CD");
-                             (100,  "C");
-                             (90,   "XC");
-                             (50,   "L");
-                             (40,   "XL");
-                             (10,   "X");
-                             (9,    "IX");
-                             (5,    "V");
-                             (4,    "IV");
-                             (1,    "I")]
+let rec toRomanLoop remainder acc thresholds =         
+    match thresholds with
+        | [] -> acc
+        | (threshold, numeral)::xs ->
+            if threshold <= remainder then toRomanLoop (remainder - threshold) (acc + numeral) thresholds
+            else toRomanLoop remainder acc xs
 
-    let rec toRomanLoop remainder acc thresholds =         
-        match thresholds with
-            | [] -> acc
-            | (threshold, numeral)::xs ->
-                if threshold <= remainder then toRomanLoop (remainder - threshold) (acc + numeral) thresholds
-                else toRomanLoop remainder acc xs
-
-    member this.toRoman(arabicNumeral: int) = toRomanLoop arabicNumeral "" numeralThresholds
+let toRoman (arabicNumeral: int) = toRomanLoop arabicNumeral "" numeralThresholds

--- a/exercises/roman-numerals/RomanNumeralTests.fs
+++ b/exercises/roman-numerals/RomanNumeralTests.fs
@@ -2,27 +2,25 @@
 
 open NUnit.Framework
 open RomanNumeral
-
-type RomanNumeralTests() =
     
-    [<TestCase(0, ExpectedResult = "")>]
-    [<TestCase(1, ExpectedResult = "I", Ignore = "Remove to run test case")>]
-    [<TestCase(2, ExpectedResult = "II", Ignore = "Remove to run test case")>]
-    [<TestCase(3, ExpectedResult = "III", Ignore = "Remove to run test case")>]
-    [<TestCase(4, ExpectedResult = "IV", Ignore = "Remove to run test case")>]
-    [<TestCase(5, ExpectedResult = "V", Ignore = "Remove to run test case")>]
-    [<TestCase(6, ExpectedResult = "VI", Ignore = "Remove to run test case")>]
-    [<TestCase(9, ExpectedResult = "IX", Ignore = "Remove to run test case")>]
-    [<TestCase(27, ExpectedResult = "XXVII", Ignore = "Remove to run test case")>]
-    [<TestCase(48, ExpectedResult = "XLVIII", Ignore = "Remove to run test case")>]
-    [<TestCase(59, ExpectedResult = "LIX", Ignore = "Remove to run test case")>]
-    [<TestCase(93, ExpectedResult = "XCIII", Ignore = "Remove to run test case")>]
-    [<TestCase(141, ExpectedResult = "CXLI", Ignore = "Remove to run test case")>]
-    [<TestCase(163, ExpectedResult = "CLXIII", Ignore = "Remove to run test case")>]
-    [<TestCase(402, ExpectedResult = "CDII", Ignore = "Remove to run test case")>]
-    [<TestCase(575, ExpectedResult = "DLXXV", Ignore = "Remove to run test case")>]
-    [<TestCase(911, ExpectedResult = "CMXI", Ignore = "Remove to run test case")>]
-    [<TestCase(1024, ExpectedResult = "MXXIV", Ignore = "Remove to run test case")>]
-    [<TestCase(3000, ExpectedResult = "MMM", Ignore = "Remove to run test case")>]
-    member tests.Convert_roman_to_arabic_numerals(arabicNumeral) =
-        RomanNumeral().toRoman(arabicNumeral)
+[<TestCase(0, ExpectedResult = "")>]
+[<TestCase(1, ExpectedResult = "I", Ignore = "Remove to run test case")>]
+[<TestCase(2, ExpectedResult = "II", Ignore = "Remove to run test case")>]
+[<TestCase(3, ExpectedResult = "III", Ignore = "Remove to run test case")>]
+[<TestCase(4, ExpectedResult = "IV", Ignore = "Remove to run test case")>]
+[<TestCase(5, ExpectedResult = "V", Ignore = "Remove to run test case")>]
+[<TestCase(6, ExpectedResult = "VI", Ignore = "Remove to run test case")>]
+[<TestCase(9, ExpectedResult = "IX", Ignore = "Remove to run test case")>]
+[<TestCase(27, ExpectedResult = "XXVII", Ignore = "Remove to run test case")>]
+[<TestCase(48, ExpectedResult = "XLVIII", Ignore = "Remove to run test case")>]
+[<TestCase(59, ExpectedResult = "LIX", Ignore = "Remove to run test case")>]
+[<TestCase(93, ExpectedResult = "XCIII", Ignore = "Remove to run test case")>]
+[<TestCase(141, ExpectedResult = "CXLI", Ignore = "Remove to run test case")>]
+[<TestCase(163, ExpectedResult = "CLXIII", Ignore = "Remove to run test case")>]
+[<TestCase(402, ExpectedResult = "CDII", Ignore = "Remove to run test case")>]
+[<TestCase(575, ExpectedResult = "DLXXV", Ignore = "Remove to run test case")>]
+[<TestCase(911, ExpectedResult = "CMXI", Ignore = "Remove to run test case")>]
+[<TestCase(1024, ExpectedResult = "MXXIV", Ignore = "Remove to run test case")>]
+[<TestCase(3000, ExpectedResult = "MMM", Ignore = "Remove to run test case")>]
+let ``Convert roman to arabic numerals`` (arabicNumeral) =
+    toRoman arabicNumeral

--- a/exercises/saddle-points/SaddlePointTest.fs
+++ b/exercises/saddle-points/SaddlePointTest.fs
@@ -5,7 +5,7 @@ open NUnit.Framework
 open SaddlePoints
 
 [<Test>]
-let ``Readme example``() =
+let ``Readme example`` () =
     let values = [ [ 9; 8; 7 ]; 
                    [ 5; 3; 2 ]; 
                    [ 6; 6; 7 ] ]
@@ -14,7 +14,7 @@ let ``Readme example``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``No saddle point``() =
+let ``No saddle point`` () =
     let values = [ [ 2; 1 ]; 
                    [ 1; 2 ] ]
     let actual = saddlePoints values
@@ -22,7 +22,7 @@ let ``No saddle point``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Saddle point``() =
+let ``Saddle point`` () =
     let values = [ [ 1; 2 ]; 
                    [ 3; 4 ] ]
     let actual = saddlePoints values
@@ -30,7 +30,7 @@ let ``Saddle point``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Another saddle point``() =
+let ``Another saddle point`` () =
     let values = [ [ 18;  3; 39; 19;  91 ]; 
                    [ 38; 10;  8; 77; 320 ]; 
                    [  3;  4;  8;  6;   7 ] ]
@@ -39,7 +39,7 @@ let ``Another saddle point``() =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Multiple saddle points``() =
+let ``Multiple saddle points`` () =
     let values = [ [ 4; 5; 4 ];
                    [ 3; 5; 5 ];
                    [ 1; 5; 4 ] ]

--- a/exercises/scrabble-score/Example.fs
+++ b/exercises/scrabble-score/Example.fs
@@ -2,15 +2,12 @@
 
 open System
 
-type Scrabble(word:string) =
+let letterScores = 
+    [("AEIOULNRST", 1); ("DG", 2); ("BCMP", 3); ("FHVWY", 4); ("K", 5); ("JX", 9); ("QZ", 10)] 
+    |> List.map (fun (letters, score) -> letters |> Seq.map (fun letter -> (letter, score))) 
+    |> Seq.concat 
+    |> Map.ofSeq
 
-    let letterScores = [("AEIOULNRST", 1); ("DG", 2); ("BCMP", 3); ("FHVWY", 4); ("K", 5); ("JX", 9); ("QZ", 10)] 
-                       |> List.map (fun (letters, score) -> letters |> Seq.map (fun letter -> (letter, score))) 
-                       |> Seq.concat 
-                       |> Map.ofSeq
+let scoreLetter letter = defaultArg (Map.tryFind letter letterScores) 0
 
-    let scoreLetter letter = defaultArg (Map.tryFind letter letterScores) 0
-
-    member val score = word.ToUpperInvariant() |> Seq.sumBy scoreLetter
-
-    static member wordScore(word) = Scrabble(word).score
+let score (word:string) = word.ToUpperInvariant() |> Seq.sumBy scoreLetter

--- a/exercises/scrabble-score/ScrabbleScoreTests.fs
+++ b/exercises/scrabble-score/ScrabbleScoreTests.fs
@@ -2,44 +2,37 @@ module ScrabbleScoreTests
 
 open NUnit.Framework
 open Scrabble
-
-type ScrabbleScoreTest() = 
   
-    [<Test>]
-    member tests.Empty_word_scores_zero() =
-        Assert.That(Scrabble("").score, Is.EqualTo(0))
+[<Test>]
+let ``Empty word scores zero`` () =
+    Assert.That(score "", Is.EqualTo(0))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Whitespace_scores_zero() =
-        Assert.That(Scrabble(" \t\n").score, Is.EqualTo(0))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Whitespace scores zero`` () =
+    Assert.That(score " \t\n", Is.EqualTo(0))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.scores_very_short_word() =
-        Assert.That(Scrabble("a").score, Is.EqualTo(1))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scores very short word`` () =
+    Assert.That(score "a", Is.EqualTo(1))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.scores_other_very_short_word() =
-        Assert.That(Scrabble("f").score, Is.EqualTo(4))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scores other very short word`` () =
+    Assert.That(score "f", Is.EqualTo(4))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Simple_word_scores_the_number_of_letters() =
-        Assert.That(Scrabble("street").score, Is.EqualTo(6))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Simple word scores the number of letters`` () =
+    Assert.That(score "street", Is.EqualTo(6))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Complicated_word_scores_more() =
-        Assert.That(Scrabble("quirky").score, Is.EqualTo(22))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Complicated word scores more`` () =
+    Assert.That(score "quirky", Is.EqualTo(22))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.scores_are_case_insensitive() =
-        Assert.That(Scrabble("MULTIBILLIONAIRE").score, Is.EqualTo(20))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Convenient_scoring() =
-        Assert.That(Scrabble.wordScore("alacrity"), Is.EqualTo(13))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scores are case insensitive`` () =
+    Assert.That(score "MULTIBILLIONAIRE", Is.EqualTo(20))

--- a/exercises/secret-handshake/SecretHandshakeTest.fs
+++ b/exercises/secret-handshake/SecretHandshakeTest.fs
@@ -5,35 +5,35 @@ open NUnit.Framework
 open SecretHandshake
 
 [<Test>]
-let ``Test 1 handshake to wink``() =
+let ``Test 1 handshake to wink`` () =
     Assert.That(handshake 1, Is.EqualTo(["wink"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 10 handshake to double blink``() =
+let ``Test 10 handshake to double blink`` () =
     Assert.That(handshake 2, Is.EqualTo(["double blink"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 100 handshake to close your eyes``() =
+let ``Test 100 handshake to close your eyes`` () =
     Assert.That(handshake 4, Is.EqualTo(["close your eyes"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test 1000 handshake to close your eyes``() =
+let ``Test 1000 handshake to close your eyes`` () =
     Assert.That(handshake 8, Is.EqualTo(["jump"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test handshake 11 to wink and double blink``() =
+let ``Test handshake 11 to wink and double blink`` () =
     Assert.That(handshake 3, Is.EqualTo(["wink"; "double blink"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test handshake 10011 to double blink and wink``() =
+let ``Test handshake 10011 to double blink and wink`` () =
     Assert.That(handshake 19, Is.EqualTo(["double blink"; "wink"]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Test handshake 11111 to all commands reversed``() =
+let ``Test handshake 11111 to all commands reversed`` () =
     Assert.That(handshake 31, Is.EqualTo(["jump"; "close your eyes"; "double blink"; "wink"]))

--- a/exercises/series/Example.fs
+++ b/exercises/series/Example.fs
@@ -1,17 +1,15 @@
-module Series
+﻿module Series
 
 open System
 
-type Series(str:string) = 
+let charToDigit c = c.ToString() |> Int32.Parse 
+let digits str = str |> List.ofSeq |> List.map charToDigit
+let slice length input = Seq.take length input |> List.ofSeq
 
-    let charToDigit c = c.ToString() |> Int32.Parse 
-    let digits = str |> List.ofSeq |> List.map charToDigit
-    let slice length input = Seq.take length input |> List.ofSeq
+let rec slicesHelper length remainder acc = 
+    if remainder |> List.length < length then acc |> List.rev
+    else slicesHelper length (remainder |> List.tail) (slice length remainder:: acc)
 
-    let rec slicesHelper length remainder acc = 
-        if remainder |> List.length < length then acc |> List.rev
-        else slicesHelper length (remainder |> List.tail) (slice length remainder:: acc)
-
-    member this.slices(length) = 
-        if length > str.Length then invalidArg "length" "Slice length must not be than input length"
-        else slicesHelper length digits []
+let slices (str:string) length = 
+    if length > str.Length then invalidArg "length" "Slice length must not be than input length"
+    else slicesHelper length (digits str) []

--- a/exercises/series/SeriesTests.fs
+++ b/exercises/series/SeriesTests.fs
@@ -4,7 +4,7 @@ open System
 open NUnit.Framework
 open Series
 
-type SeriesTests() =
+type SeriesTests () =
     static member SliceOneTestData = 
         [| 
             ("01234", [[0]; [1]; [2]; [3]; [4]]);
@@ -12,10 +12,9 @@ type SeriesTests() =
         |]
 
     [<TestCaseSource("SliceOneTestData")>]
-    member tests.Series_of_one_splits_to_one_digit(testData: string * int list list) =
+    member this.``Series of one splits to one digit`` (testData: string * int list list) =
         let input, expected = testData
-        let series = new Series(input)
-        Assert.That(series.slices(1), Is.EqualTo(expected))
+        Assert.That(slices input 1, Is.EqualTo(expected))
 
     static member SliceTwoTestData =
         [| 
@@ -25,11 +24,10 @@ type SeriesTests() =
         |]
 
     [<TestCaseSource("SliceTwoTestData")>]
-    [<Ignore("Remove to run test")>]
-    member tests.Series_of_two_splits_to_two_digits(testData: string * int list list) =
+    [<Ignore("Remove to run test")>]  
+    member this.``Series of two splits to two digits`` (testData: string * int list list) =
         let input, expected = testData
-        let series = new Series(input)
-        Assert.That(series.slices(2), Is.EqualTo(expected))
+        Assert.That(slices input 2, Is.EqualTo(expected))
 
     static member SliceThreeTestData =
         [| 
@@ -40,10 +38,9 @@ type SeriesTests() =
 
     [<TestCaseSource("SliceThreeTestData")>]
     [<Ignore("Remove to run test")>]
-    member tests.Series_of_three_splits_to_three_digits(testData: string * int list list) =
+    member this.``Series of three splits to three digits`` (testData: string * int list list) =
         let input, expected = testData
-        let series = new Series(input)
-        Assert.That(series.slices(3), Is.EqualTo(expected))
+        Assert.That(slices input 3, Is.EqualTo(expected))
 
     static member SliceFourTestData =
         [| 
@@ -53,10 +50,9 @@ type SeriesTests() =
 
     [<TestCaseSource("SliceFourTestData")>]
     [<Ignore("Remove to run test")>]
-    member tests.Series_of_four_splits_to_four_digits(testData: string * int list list) =
+    member this.``Series of four splits to four digits`` (testData: string * int list list) =
         let input, expected = testData
-        let series = new Series(input)
-        Assert.That(series.slices(4), Is.EqualTo(expected))
+        Assert.That(slices input 4, Is.EqualTo(expected))
 
     static member SliceFiveTestData =
         [| 
@@ -64,15 +60,13 @@ type SeriesTests() =
             ("81228", [[8; 1; 2; 2; 8]])
         |]
 
-    [<TestCaseSource("SliceFiveTestData")>]
+    [<TestCaseSource("SliceFiveTestData")>]    
     [<Ignore("Remove to run test")>]
-    member tests.Series_of_five_splits_to_five_digits(testData: string * int list list) =
+    member this.``Series of five splits to five digits`` (testData: string * int list list) =
         let input, expected = testData
-        let series = new Series(input)
-        Assert.That(series.slices(5), Is.EqualTo(expected))
+        Assert.That(slices input 5, Is.EqualTo(expected))
 
     [<TestCase("01234", 6, Ignore = "Remove to run test case")>]
     [<TestCase("01032987583", 19, Ignore = "Remove to run test case")>]
-    member tests.Slice_longer_than_input_is_not_allowed(input, slice) =
-        let series = new Series(input)
-        Assert.Throws<System.ArgumentException>(fun () -> series.slices(slice) |> ignore) |> ignore
+    member this.``Slice longer than input is not allowed`` (input, slice) =
+        Assert.That((fun () -> slices input slice |> ignore), Throws.Exception)

--- a/exercises/sieve/SieveTest.fs
+++ b/exercises/sieve/SieveTest.fs
@@ -5,17 +5,17 @@ open NUnit.Framework
 open Sieve
 
 [<Test>]
-let ``Finds first prime``() =
+let ``Finds first prime`` () =
     Assert.That(primesUpTo 2, Is.EqualTo([ 2 ]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Finds primes up to 10``() =
+let ``Finds primes up to 10`` () =
     Assert.That(primesUpTo 10, Is.EqualTo([ 2; 3; 5; 7 ]))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Finds primes up to 1000``() =
+let ``Finds primes up to 1000`` () =
     Assert.That(primesUpTo 1000,
         Is.EqualTo(
             [

--- a/exercises/simple-cipher/SimpleCipherTest.fs
+++ b/exercises/simple-cipher/SimpleCipherTest.fs
@@ -9,19 +9,19 @@ let plainText = "abcdefghij"
 let key = "abcdefghij";
 
 [<Test>]
-let ``Encode random uses key made of letters``() =
+let ``Encode random uses key made of letters`` () =
     let (key, _) = encodeRandom plainText
     Assert.That(key, Does.Match("[a-z]+"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode random uses key of 100 characters``() =
+let ``Encode random uses key of 100 characters`` () =
     let (key, _) = encodeRandom plainText
     Assert.That(key, Has.Length.EqualTo(100))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode random uses randomly generated key``() =
+let ``Encode random uses randomly generated key`` () =
     let keys = List.init 100 (fun _ -> encodeRandom plainText |> fst)
     Assert.That(keys |> List.distinct, Is.EqualTo(keys))
 
@@ -30,84 +30,83 @@ let ``Encode random uses randomly generated key``() =
 // will always output the key verbatim.
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode random can encode``() =
+let ``Encode random can encode`` () =
     let (key, encoded) = encodeRandom "aaaaaaaaaa"
     Assert.That(encoded, Is.EqualTo(key.Substring(0, 10)))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode random can decode``() =    
+let ``Encode random can decode`` () =    
     let (key, _) = encodeRandom "aaaaaaaaaa"
     Assert.That(decode key (key.Substring(0, 10)), Is.EqualTo("aaaaaaaaaa"))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode random is reversible``() =
+let ``Encode random is reversible`` () =
     let (key, encoded) = encodeRandom plainText
     Assert.That(decode key encoded, Is.EqualTo(plainText))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher can encode with given key``() =
+let ``Cipher can encode with given key`` () =
     Assert.That(encode key "aaaaaaaaaa", Is.EqualTo("abcdefghij"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher can decode with given key``() =
+let ``Cipher can decode with given key`` () =
     Assert.That(decode key "abcdefghij", Is.EqualTo("aaaaaaaaaa"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher is reversible given key``() =
+let ``Cipher is reversible given key`` () =
     Assert.That(encode key plainText |> decode key, Is.EqualTo(plainText))
     
 [<Test>]
-[<Ignore("Remove to run test")>]
-let ``Cipher can double shift encode``() =
+let ``Cipher can double shift encode`` () =
     let plainText = "iamapandabear"
     Assert.That(encode plainText plainText, Is.EqualTo("qayaeaagaciai"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher can wrap encode``() =
+let ``Cipher can wrap encode`` () =
     Assert.That(encode key "zzzzzzzzzz", Is.EqualTo("zabcdefghi"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher can encode a message that is shorter than the key``() =
+let ``Cipher can encode a message that is shorter than the key`` () =
     Assert.That(encode key "aaaaa", Is.EqualTo("abcde"))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cipher can decode a message that is shorter than the key``() =
+let ``Cipher can decode a message that is shorter than the key`` () =
     Assert.That(decode key "abcde", Is.EqualTo("aaaaa"))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode throws with an all caps key``() =
+let ``Encode throws with an all caps key`` () =
     let key = "ABCDEF"
     Assert.That((fun () -> encode key plainText |> ignore), Throws.Exception)
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode throws with any caps key``() =
+let ``Encode throws with any caps key`` () =
     let key = "abcdEFg"
     Assert.That((fun () -> encode key plainText |> ignore), Throws.Exception)
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode throws with numeric key``() =
+let ``Encode throws with numeric key`` () =
     let key = "12345"
     Assert.That((fun () -> encode key plainText |> ignore), Throws.Exception)
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode throws with any numeric key``() =
+let ``Encode throws with any numeric key`` () =
     let key = "abcd345ef"
     Assert.That((fun () -> encode key plainText |> ignore), Throws.Exception)
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Encode throws with empty key``() =
+let ``Encode throws with empty key`` () =
     let key = ""
     Assert.That((fun () -> encode key plainText |> ignore), Throws.Exception)

--- a/exercises/simple-linked-list/SimpleLinkedListTest.fs
+++ b/exercises/simple-linked-list/SimpleLinkedListTest.fs
@@ -5,49 +5,49 @@ open NUnit.Framework
 open SimpleLinkedList
 
 [<Test>]
-let ``Empty list``() =
+let ``Empty list`` () =
     let list = nil
     Assert.That(isNil list, Is.True)
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Single item list value``() =
+let ``Single item list value`` () =
     let list = create 1 nil
     Assert.That(datum list, Is.EqualTo(1))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Single item list has no next item``() =
+let ``Single item list has no next item`` () =
     let list = create 1 nil
     Assert.That(next list |> isNil, Is.True)
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Two item list first value``() =
+let ``Two item list first value`` () =
     let list = create 2 (create 1 nil)
     Assert.That(datum list, Is.EqualTo(2))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Two item list second value``() =
+let ``Two item list second value`` () =
     let list = create 2 (create 1 nil)
     Assert.That(next list |> datum, Is.EqualTo(1))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Two item list second item has no next``() =
+let ``Two item list second item has no next`` () =
     let list = create 2 (create 1 nil)
     Assert.That(next list |> next |> isNil, Is.True)
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``To list``() =
+let ``To list`` () =
     let values = create 2 (create 1 nil) |> toList
     Assert.That(values, Is.EqualTo([2; 1]))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``From list``() =
+let ``From list`` () =
     let list = fromList [11; 7; 5; 3; 2]
     Assert.That(list |> datum, Is.EqualTo(11))
     Assert.That(list |> next |> datum, Is.EqualTo(7))

--- a/exercises/space-age/Example.fs
+++ b/exercises/space-age/Example.fs
@@ -1,56 +1,31 @@
 ﻿module SpaceAge
 
-let EARTH_ORBIT_IN_SECONDS = 31557600m
+open System
 
-type Planets =
+type Planet = 
+    | Mercury
+    | Venus
     | Earth
     | Mars
-    | Venus
-    | Mercury
     | Jupiter
     | Saturn
-    | Uranus
     | Neptune
+    | Uranus
 
-type SpaceAge(seconds: decimal) =
-    let periodOfEarthYearToPlanet = 
-        [
-            Planets.Earth, 1m;
-            Planets.Mercury, 0.2408467m;
-            Planets.Venus, 0.61519726m;
-            Planets.Mars, 1.8808158m;
-            Planets.Jupiter, 11.862615m;
-            Planets.Saturn, 29.447498m;
-            Planets.Neptune, 164.79132m;
-            Planets.Uranus, 84.016846m;
-        ]
-        |> Map.ofList
+let secondsOnEarth = 31557600m    
 
-    let calculateAge(periodInEarthYears: decimal) =
-        System.Math.Round(seconds / (EARTH_ORBIT_IN_SECONDS * periodInEarthYears), 2)
+let planetPeriods = 
+    [Mercury, 0.2408467m;
+     Venus,   0.61519726m;
+     Earth,   1.0m;
+     Mars,    1.8808158m;
+     Jupiter, 11.862615m;
+     Saturn,  29.447498m;
+     Uranus,  84.016846m;
+     Neptune, 164.79132m] 
+    |> Map.ofList
 
-    member this.Seconds = seconds
-
-    member this.onEarth() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Earth])
-
-    member this.onMercury() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Mercury])
-
-    member this.onVenus() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Venus])
-
-    member this.onMars() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Mars])
-
-    member this.onJupiter() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Jupiter])
-
-    member this.onSaturn() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Saturn])
-
-    member this.onNeptune() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Neptune])
-
-    member this.onUranus() =
-        calculateAge(periodOfEarthYearToPlanet.[Planets.Uranus])
+let spaceAge planet (seconds: decimal) = 
+    let yearsUsingPeriod (period:decimal) = Math.Round((seconds / period) / secondsOnEarth, 2)
+        
+    yearsUsingPeriod planetPeriods.[planet]

--- a/exercises/space-age/SpaceAgeTest.fs
+++ b/exercises/space-age/SpaceAgeTest.fs
@@ -2,70 +2,57 @@
 
 open NUnit.Framework
 open SpaceAge
-
-type SpaceAgeTest() =
     
-    [<Test>]
-    member tests.Age_in_seconds() =
-        Assert.That<decimal>(SpaceAge(1000000m).Seconds, Is.EqualTo(1000000))
+[<Test>]
+let ``Age on earth`` () =
+    let seconds = 1000000000m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(31.69m))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_earth() =
-        Assert.That<decimal>(SpaceAge(1000000000m).onEarth, Is.EqualTo(31.69))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on mercury`` () =
+    let seconds = 2134835688m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(67.65m))
+    Assert.That(spaceAge Planet.Mercury seconds, Is.EqualTo(280.88m))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_mercury() =
-        let spaceAge = SpaceAge(2134835688m)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on venus`` () =
+    let seconds = 189839836m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(6.02m))
+    Assert.That(spaceAge Planet.Venus seconds, Is.EqualTo(9.78m))
 
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(67.65))
-        Assert.That<decimal>(spaceAge.onMercury, Is.EqualTo(280.88))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on mars`` () =
+    let seconds = 2329871239m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(73.83m))
+    Assert.That(spaceAge Planet.Mars seconds, Is.EqualTo(39.25m))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_venus() =
-        let spaceAge = SpaceAge(189839836m)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on jupiter`` () =
+    let seconds = 901876382m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(28.58m))
+    Assert.That(spaceAge Planet.Jupiter seconds, Is.EqualTo(2.41m))
 
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(6.02))
-        Assert.That<decimal>(spaceAge.onVenus, Is.EqualTo(9.78))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on saturn`` () =
+    let seconds = 3000000000m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(95.06m))
+    Assert.That(spaceAge Planet.Saturn seconds, Is.EqualTo(3.23m))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_mars() =
-        let spaceAge = SpaceAge(2329871239m)
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on uranus`` () =
+    let seconds = 3210123456m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(101.72m))
+    Assert.That(spaceAge Planet.Uranus seconds, Is.EqualTo(1.21m))
 
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(73.83))
-        Assert.That<decimal>(spaceAge.onMars, Is.EqualTo(39.25))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_jupiter() =
-        let spaceAge = SpaceAge(901876382m)
-
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(28.58))
-        Assert.That<decimal>(spaceAge.onJupiter, Is.EqualTo(2.41))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_saturn() =
-        let spaceAge = SpaceAge(3000000000m)
-
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(95.06))
-        Assert.That<decimal>(spaceAge.onSaturn, Is.EqualTo(3.23))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_uranus() =
-        let spaceAge = SpaceAge(3210123456m)
-
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(101.72))
-        Assert.That<decimal>(spaceAge.onUranus, Is.EqualTo(1.21))
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Age_on_neptune() =
-        let spaceAge = SpaceAge(8210123456m)
-
-        Assert.That<decimal>(spaceAge.onEarth, Is.EqualTo(260.16))
-        Assert.That<decimal>(spaceAge.onNeptune, Is.EqualTo(1.58))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Age on neptune`` () =
+    let seconds = 8210123456m
+    Assert.That(spaceAge Planet.Earth seconds, Is.EqualTo(260.16m))
+    Assert.That(spaceAge Planet.Neptune seconds, Is.EqualTo(1.58m))

--- a/exercises/strain/Example.fs
+++ b/exercises/strain/Example.fs
@@ -1,5 +1,5 @@
 ﻿module Seq
 
-    let keep pred xs = seq { for x in xs do if pred x then yield x }
+let keep pred xs = seq { for x in xs do if pred x then yield x }
 
-    let discard pred = keep (not << pred)
+let discard pred = keep (not << pred)

--- a/exercises/strain/Strain.fs
+++ b/exercises/strain/Strain.fs
@@ -1,5 +1,0 @@
-﻿module Seq
-
-    let keep pred xs = ???
-
-    let discard pred xs = ???

--- a/exercises/strain/StrainTests.fs
+++ b/exercises/strain/StrainTests.fs
@@ -3,84 +3,92 @@ module StrainTests
 open System.Collections.Specialized
 open NUnit.Framework
 
-type StrainTests() =
-    [<Test>]
-    member tests.Empty_keep() =
-        Assert.That([] |> Seq.keep (fun x -> x < 10), Is.EqualTo([]))
+// Note: to add your own functions to an existing module, just put your 
+// functions in a module matching the existing module name. Your code
+// should thus look something like this:
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Keep_everything() =
-        Assert.That(set [1; 2; 3] |> Seq.keep (fun x -> x < 10), Is.EqualTo(set [1; 2; 3]))
+// module Seq
+//
+// let keep pred xs = ???
+// let discard pred xs = ???
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Keep_first_and_last() =
-        Assert.That([|1; 2; 3|] |> Seq.keep (fun x -> x % 2 <> 0), Is.EqualTo([|1; 3|]))
+[<Test>]
+let ``Empty keep`` () =
+    Assert.That([] |> Seq.keep (fun x -> x < 10), Is.EqualTo([]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Keep_neither_first_nor_last() =
-        Assert.That([1; 2; 3; 4; 5] |> Seq.keep (fun x -> x % 2 = 0), Is.EqualTo([2; 4]))
+[<Test>]
+[<Ignore("Remove to run test")>]  
+let ``Keep everything`` () =
+    Assert.That(set [1; 2; 3] |> Seq.keep (fun x -> x < 10), Is.EqualTo(set [1; 2; 3]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Keep_strings() =
-        let words = "apple zebra banana zombies cherimoya zelot".Split(' ');
-        Assert.That(words |> Seq.keep (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("zebra zombies zelot".Split(' ')))
+[<Test>]
+[<Ignore("Remove to run test")>] 
+let ``Keep first and last`` () =
+    Assert.That([|1; 2; 3|] |> Seq.keep (fun x -> x % 2 <> 0), Is.EqualTo([|1; 3|]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Keep_arrays() =
-        let actual = [|
-                        [|1; 2; 3|];
-                        [|5; 5; 5|];
-                        [|5; 1; 2|];
-                        [|2; 1; 2|];
-                        [|1; 5; 2|];
-                        [|2; 2; 1|];
-                        [|1; 2; 5|]
-                     |]
-        let expected = [| [|5; 5; 5|]; [|5; 1; 2|]; [|1; 5; 2|]; [|1; 2; 5|] |]
-        Assert.That(actual |> Seq.keep (Array.exists ((=) 5)), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Keep neither first nor last`` () =
+    Assert.That([1; 2; 3; 4; 5] |> Seq.keep (fun x -> x % 2 = 0), Is.EqualTo([2; 4]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Empty_discard() =
-        Assert.That([] |> Seq.discard (fun x -> x < 10), Is.EqualTo([]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Keep strings`` () =
+    let words = "apple zebra banana zombies cherimoya zelot".Split(' ');
+    Assert.That(words |> Seq.keep (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("zebra zombies zelot".Split(' ')))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Discard_nothing() =
-        Assert.That(set [1; 2; 3] |> Seq.discard (fun x -> x > 10), Is.EqualTo(set [1; 2; 3]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Keep arrays`` () =
+    let actual = [|
+                    [|1; 2; 3|];
+                    [|5; 5; 5|];
+                    [|5; 1; 2|];
+                    [|2; 1; 2|];
+                    [|1; 5; 2|];
+                    [|2; 2; 1|];
+                    [|1; 2; 5|]
+                    |]
+    let expected = [| [|5; 5; 5|]; [|5; 1; 2|]; [|1; 5; 2|]; [|1; 2; 5|] |]
+    Assert.That(actual |> Seq.keep (Array.exists ((=) 5)), Is.EqualTo(expected))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Discard_first_and_last() =
-        Assert.That([|1; 2; 3|] |> Seq.discard (fun x -> x % 2 <> 0), Is.EqualTo([|2|]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Empty discard`` () =
+    Assert.That([] |> Seq.discard (fun x -> x < 10), Is.EqualTo([]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Discard_neither_first_nor_last() =
-        Assert.That([1; 2; 3; 4; 5] |> Seq.discard (fun x -> x % 2 = 0), Is.EqualTo([1; 3; 5]))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Discard nothing`` () =
+    Assert.That(set [1; 2; 3] |> Seq.discard (fun x -> x > 10), Is.EqualTo(set [1; 2; 3]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Discard_strings() =
-        let words = "apple zebra banana zombies cherimoya zelot".Split(' ')
-        Assert.That(words |> Seq.discard (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("apple banana cherimoya".Split(' ')))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Discard first and last`` () =
+    Assert.That([|1; 2; 3|] |> Seq.discard (fun x -> x % 2 <> 0), Is.EqualTo([|2|]))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Discard_arrays() =
-        let actual = [|
-                        [|1; 2; 3|];
-                        [|5; 5; 5|];
-                        [|5; 1; 2|];
-                        [|2; 1; 2|];
-                        [|1; 5; 2|];
-                        [|2; 2; 1|];
-                        [|1; 2; 5|]
-                     |]
-        let expected = [| [|1; 2; 3|]; [|2; 1; 2|]; [|2; 2; 1|] |]
-        Assert.That(actual |> Seq.discard (Array.exists ((=) 5)), Is.EqualTo(expected))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Discard neither first nor last`` () =
+    Assert.That([1; 2; 3; 4; 5] |> Seq.discard (fun x -> x % 2 = 0), Is.EqualTo([1; 3; 5]))
+
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Discard strings`` () =
+    let words = "apple zebra banana zombies cherimoya zelot".Split(' ')
+    Assert.That(words |> Seq.discard (fun (x:string) -> x.StartsWith("z")), Is.EqualTo("apple banana cherimoya".Split(' ')))
+
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Discard arrays`` () =
+    let actual = [|
+                    [|1; 2; 3|];
+                    [|5; 5; 5|];
+                    [|5; 1; 2|];
+                    [|2; 1; 2|];
+                    [|1; 5; 2|];
+                    [|2; 2; 1|];
+                    [|1; 2; 5|]
+                    |]
+    let expected = [| [|1; 2; 3|]; [|2; 1; 2|]; [|2; 2; 1|] |]
+    Assert.That(actual |> Seq.discard (Array.exists ((=) 5)), Is.EqualTo(expected))

--- a/exercises/sum-of-multiples/Example.fs
+++ b/exercises/sum-of-multiples/Example.fs
@@ -3,4 +3,6 @@
 let sumOfMultiples numbers upperBound =
     let isMultiple x = numbers |> List.exists (fun y -> x % y = 0) 
     
-    [1 .. upperBound - 1] |> List.filter isMultiple |> List.sum
+    [1 .. upperBound - 1] 
+    |> List.filter isMultiple 
+    |> List.sum

--- a/exercises/sum-of-multiples/SumOfMultiplesTest.fs
+++ b/exercises/sum-of-multiples/SumOfMultiplesTest.fs
@@ -1,24 +1,28 @@
-module SumOfMultiplesTest
+﻿module SumOfMultiplesTest
 
 open NUnit.Framework
 open SumOfMultiples
 
 [<Test>]
-let ``Sum to 1``() =
+let ``Sum to 1`` () =
     Assert.That(sumOfMultiples [3; 5] 0, Is.EqualTo(0))
 
 [<Test>]
-let ``Sum to 3``() =
+[<Ignore("Remove to run test")>]
+let ``Sum to 3`` () =
     Assert.That(sumOfMultiples [3; 5] 3, Is.EqualTo(0))
 
 [<Test>]
-let ``Sum to 10``() =
+[<Ignore("Remove to run test")>]
+let ``Sum to 10`` () =
     Assert.That(sumOfMultiples [3; 5] 10, Is.EqualTo(23))
 
 [<Test>]
-let ``Sum to 20``() =
+[<Ignore("Remove to run test")>]
+let ``Sum to 20`` () =
     Assert.That(sumOfMultiples [7; 13; 17] 20, Is.EqualTo(51))
 
 [<Test>]
-let ``Sum to 10000``() =
+[<Ignore("Remove to run test")>]
+let ``Sum to 10000`` () =
     Assert.That(sumOfMultiples [43; 47] 10000, Is.EqualTo(2203160))

--- a/exercises/triangle/Example.fs
+++ b/exercises/triangle/Example.fs
@@ -1,26 +1,22 @@
 ﻿module Triangle
 
+open System
+
 type TriangleKind =
     | Equilateral
     | Isosceles
     | Scalene
 
-type Triangle(side1: decimal, side2: decimal, side3: decimal) =
-    let hasSidesAsZeroes() = 
-        side1 = 0m && side2 = 0m && side3 = 0m
+let kind (x: decimal) (y: decimal) (z: decimal) = 
+    let hasZeroSides = x = 0m && y = 0m && z = 0m
+    let hasNegativeSide = x < 0m || y < 0m || z < 0m
+    let violatesTriangleEquality = x + y <= z || x + z <= y || y + z <= x
 
-    let hasSidesLessThanZero() =
-        side1 < 0m || side2 < 0m || side3 < 0m
+    let isInvalid = hasZeroSides || hasNegativeSide || violatesTriangleEquality
+    let isEquilateral = x = y && y = z
+    let isIsosceles = x = y || y = z || x = z
 
-    let hasTriangleInequality() =
-        side1 + side2 <= side3 || side1 + side3 <= side2 || side2 + side3 <= side1
-
-    member this.Kind() =
-        if hasSidesAsZeroes() || hasSidesLessThanZero() || hasTriangleInequality() then invalidOp "Invalid sides for triangle."
-
-        Seq.distinct [side1; side2; side3]
-            |> Seq.length
-            |> function
-                | 1 -> TriangleKind.Equilateral
-                | 2 -> TriangleKind.Isosceles
-                | _ -> TriangleKind.Scalene
+    if   isInvalid     then invalidOp "Invalid triangle."
+    elif isEquilateral then TriangleKind.Equilateral
+    elif isIsosceles   then TriangleKind.Isosceles
+    else TriangleKind.Scalene

--- a/exercises/triangle/TriangleTest.fs
+++ b/exercises/triangle/TriangleTest.fs
@@ -2,79 +2,78 @@
 
 open NUnit.Framework
 open Triangle
+open System
 
-type TriangleTest() =
+[<Test>]
+let ``Equilateral triangles have equal sides`` () =
+    Assert.That(kind 2m 2m 2m, Is.EqualTo(TriangleKind.Equilateral))
 
-    [<Test>]
-    member tests.Equilateral_triangles_have_equal_sides() =
-        Assert.That(Triangle(2m, 2m, 2m).Kind(), Is.EqualTo(TriangleKind.Equilateral))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Larger equilateral triangles also have equal sides`` () =
+    Assert.That(kind 10m 10m 10m, Is.EqualTo(TriangleKind.Equilateral))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Larger_equilateral_triangles_also_have_equal_sides() =
-        Assert.That(Triangle(10m, 10m, 10m).Kind(), Is.EqualTo(TriangleKind.Equilateral))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Isosceles triangles have last two sides equal`` () =
+    Assert.That(kind 3m 4m 4m, Is.EqualTo(TriangleKind.Isosceles))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Isosceles_triangles_have_last_two_sides_equal() =
-        Assert.That(Triangle(3m, 4m, 4m).Kind(), Is.EqualTo(TriangleKind.Isosceles))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Isosceles triangles have first and last sides equal`` () =
+    Assert.That(kind 4m 3m 4m, Is.EqualTo(TriangleKind.Isosceles))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Isosceles_triangles_have_first_and_last_sides_equal() =
-        Assert.That(Triangle(4m, 3m, 4m).Kind(), Is.EqualTo(TriangleKind.Isosceles))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Isosceles triangles have two first sides equal`` () =
+    Assert.That(kind 4m 4m 3m, Is.EqualTo(TriangleKind.Isosceles))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Isosceles_triangles_have_two_first_sides_equal() =
-        Assert.That(Triangle(4m, 4m, 3m).Kind(), Is.EqualTo(TriangleKind.Isosceles))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Isosceles triangles have in fact exactly two sides equal`` () =
+    Assert.That(kind 10m 10m 3m, Is.EqualTo(TriangleKind.Isosceles))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Isosceles_triangles_have_in_fact_exactly_two_sides_equal() =
-        Assert.That(Triangle(10m, 10m, 3m).Kind(), Is.EqualTo(TriangleKind.Isosceles))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scalene triangles have no equal sides`` () =
+    Assert.That(kind 3m 4m 5m, Is.EqualTo(TriangleKind.Scalene))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Scalene_triangles_have_no_equal_sides() =
-        Assert.That(Triangle(3m, 4m, 5m).Kind(), Is.EqualTo(TriangleKind.Scalene))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scalene triangles have no equal sides at a larger scale too`` () =
+    Assert.That(kind 10m 11m 12m, Is.EqualTo(TriangleKind.Scalene))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Scalene_triangles_have_no_equal_sides_at_a_larger_scale_too() =
-        Assert.That(Triangle(10m, 11m, 12m).Kind(), Is.EqualTo(TriangleKind.Scalene))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Scalene triangles have no equal sides in descending order either`` () =
+    Assert.That(kind 5m 4m 2m, Is.EqualTo(TriangleKind.Scalene))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Scalene_triangles_have_no_equal_sides_in_descending_order_either() =
-        Assert.That(Triangle(5m, 4m, 2m).Kind(), Is.EqualTo(TriangleKind.Scalene))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Very small triangles are legal`` () =
+    Assert.That(kind 0.4m 0.6m 0.3m, Is.EqualTo(TriangleKind.Scalene))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Very_small_triangles_are_legal() =
-        Assert.That(Triangle(0.4m, 0.6m, 0.3m).Kind(), Is.EqualTo(TriangleKind.Scalene))
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Triangles with no size are illegal`` () =
+    Assert.That((fun () -> kind 0m 0m 0m |> ignore), Throws.InvalidOperationException)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Triangles_with_no_size_are_illegal() =
-        Assert.Throws<System.InvalidOperationException>(fun () -> Triangle(0m, 0m, 0m).Kind() |> ignore) |> ignore
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Triangles with negative sides are illegal`` () =
+    Assert.That((fun () -> kind 3m 4m -5m |> ignore), Throws.InvalidOperationException)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Triangles_with_negative_sides_are_illegal() =
-        Assert.Throws<System.InvalidOperationException>(fun () -> Triangle(3m, 4m, -5m).Kind() |> ignore) |> ignore
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Triangles violating triangle inequality are illegal`` () =
+    Assert.That((fun () -> kind 1m 1m 3m |> ignore), Throws.InvalidOperationException)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Triangles_violating_triangle_inequality_are_illegal() =
-        Assert.Throws<System.InvalidOperationException>(fun () -> Triangle(1m, 1m, 3m).Kind() |> ignore) |> ignore
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Triangles violating triangle inequality are illegal 2`` () =
+    Assert.That((fun () -> kind 2m 4m 2m |> ignore), Throws.InvalidOperationException)
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Triangles_violating_triangle_inequality_are_illegal_2() =
-        Assert.Throws<System.InvalidOperationException>(fun () -> Triangle(2m, 4m, 2m).Kind() |> ignore) |> ignore
-
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Triangles_violating_triangle_inequality_are_illegal_3() =
-        Assert.Throws<System.InvalidOperationException>(fun () -> Triangle(7m, 3m, 2m).Kind() |> ignore) |> ignore
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Triangles violating triangle inequality are illegal 3`` () =
+    Assert.That((fun () -> kind 7m 3m 2m |> ignore), Throws.InvalidOperationException)

--- a/exercises/trinary/Example.fs
+++ b/exercises/trinary/Example.fs
@@ -1,13 +1,13 @@
 ﻿module Trinary
 
-type Trinary(input: string) =
-    let rec toDecimalLoop acc input = 
-        if input = "" then acc
-        else 
-            let head = input.Chars 0
-            let tail = input.Substring 1
-            match head with
-                | '0' | '1' | '2' -> toDecimalLoop (acc * 3 + (int)head - (int)'0') tail
-                | _  -> 0   
+let isValid char = 
+    match char with
+    | '0' | '1' | '2' -> true
+    | _  -> false
 
-    member this.toDecimal() = toDecimalLoop 0 input
+let charToDecimal char = (int)char - (int)'0'
+
+let toDecimal(input: string) = 
+    let chars = input.ToCharArray()
+    if Array.forall isValid chars then Array.fold (fun acc c -> acc * 3 + charToDecimal c) 0 chars
+    else 0

--- a/exercises/trinary/TrinaryTests.fs
+++ b/exercises/trinary/TrinaryTests.fs
@@ -2,25 +2,23 @@
 
 open NUnit.Framework
 open Trinary
-
-type TrinaryTests() =
     
-    [<TestCase("1", ExpectedResult = 1)>]
-    [<TestCase("2", ExpectedResult = 2, Ignore = "Remove to run test case")>]
-    [<TestCase("10", ExpectedResult = 3, Ignore = "Remove to run test case")>]
-    [<TestCase("11", ExpectedResult = 4, Ignore = "Remove to run test case")>]
-    [<TestCase("100", ExpectedResult = 9, Ignore = "Remove to run test case")>]
-    [<TestCase("112", ExpectedResult = 14, Ignore = "Remove to run test case")>]
-    [<TestCase("222", ExpectedResult = 26, Ignore = "Remove to run test case")>]
-    [<TestCase("1122000120", ExpectedResult = 32091, Ignore = "Remove to run test case")>]
-    member tests.Binary_converts_to_decimal(input) =
-        Trinary(input).toDecimal()
+[<TestCase("1", ExpectedResult = 1)>]
+[<TestCase("2", ExpectedResult = 2, Ignore = "Remove to run test case")>]
+[<TestCase("10", ExpectedResult = 3, Ignore = "Remove to run test case")>]
+[<TestCase("11", ExpectedResult = 4, Ignore = "Remove to run test case")>]
+[<TestCase("100", ExpectedResult = 9, Ignore = "Remove to run test case")>]
+[<TestCase("112", ExpectedResult = 14, Ignore = "Remove to run test case")>]
+[<TestCase("222", ExpectedResult = 26, Ignore = "Remove to run test case")>]
+[<TestCase("1122000120", ExpectedResult = 32091, Ignore = "Remove to run test case")>]
+let ``Binary converts to decimal`` input =
+    toDecimal input
 
-    [<TestCase("carrot", Ignore = "Remove to run test case")>]
-    [<TestCase("3", Ignore = "Remove to run test case")>]
-    [<TestCase("6", Ignore = "Remove to run test case")>]
-    [<TestCase("9", Ignore = "Remove to run test case")>]
-    [<TestCase("124578", Ignore = "Remove to run test case")>]
-    [<TestCase("abc1z", Ignore = "Remove to run test case")>]
-    member tests.Invalid_binary_is_decimal_0(input) =
-        Assert.That(Trinary(input).toDecimal(), Is.EqualTo(0))
+[<TestCase("carrot", Ignore = "Remove to run test case")>]
+[<TestCase("3", Ignore = "Remove to run test case")>]
+[<TestCase("6", Ignore = "Remove to run test case")>]
+[<TestCase("9", Ignore = "Remove to run test case")>]
+[<TestCase("124578", Ignore = "Remove to run test case")>]
+[<TestCase("abc1z", Ignore = "Remove to run test case")>]
+let ``Invalid binary is decimal 0`` input =
+    Assert.That(toDecimal input, Is.EqualTo(0))

--- a/exercises/twelve-days/Example.fs
+++ b/exercises/twelve-days/Example.fs
@@ -15,6 +15,6 @@ let private allVerses = [|
     "On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n";
 |]
 
-let verse number = allVerses.[number - 1] 
+let verse number = Array.item (number - 1) allVerses
 let verses start stop = allVerses.[(start - 1)..(stop - 1)] |> Array.fold (fun acc x -> acc + x + "\n") ""
 let song = verses 1 (allVerses.Length)

--- a/exercises/twelve-days/TwelveDaysTest.fs
+++ b/exercises/twelve-days/TwelveDaysTest.fs
@@ -5,79 +5,79 @@ open NUnit.Framework
 open TwelveDaysSong
 
 [<Test>]
-let ``Return verse 1``() =
+let ``Return verse 1`` () =
     let expected = "On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.\n"
     Assert.That(verse 1, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 2``() =
+let ``Return verse 2`` () =
     let expected = "On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 2, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 3``() =
+let ``Return verse 3`` () =
     let expected = "On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 3, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 4``() =
+let ``Return verse 4`` () =
     let expected = "On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 4, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 5``() =
+let ``Return verse 5`` () =
     let expected = "On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 5, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 6``() =
+let ``Return verse 6`` () =
     let expected = "On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 6, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 7``() =
+let ``Return verse 7`` () =
     let expected = "On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 7, Is.EqualTo(expected))
         
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 8``() =
+let ``Return verse 8`` () =
     let expected = "On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 8, Is.EqualTo(expected))
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 9``() =
+let ``Return verse 9`` () =
     let expected = "On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 9, Is.EqualTo(expected))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 10``() =
+let ``Return verse 10`` () =
     let expected = "On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 10, Is.EqualTo(expected))
    
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 11``() =
+let ``Return verse 11`` () =
     let expected = "On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 11, Is.EqualTo(expected))
    
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return verse 12``() =
+let ``Return verse 12`` () =
     let expected = "On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
     Assert.That(verse 12, Is.EqualTo(expected))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return multiple verses``() =
+let ``Return multiple verses`` () =
     let expected = "On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.\n\n" +
                    "On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" +
                    "On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n"
@@ -86,5 +86,5 @@ let ``Return multiple verses``() =
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Return entire song``() =
+let ``Return entire song`` () =
     Assert.That(verses 1 12, Is.EqualTo(song))

--- a/exercises/word-count/Example.fs
+++ b/exercises/word-count/Example.fs
@@ -2,11 +2,9 @@
 
 open System.Text.RegularExpressions
 
-type Phrase(phrase: string) =
-
-    member this.wordCount() = 
-        Regex.Matches(phrase.ToLowerInvariant(), @"\w+('\w+)*") 
-        |> Seq.cast<Match> 
-        |> Seq.groupBy (fun m -> m.Value)
-        |> Seq.map (fun (word, occurrences) -> word, occurrences |> Seq.length)                     
-        |> Map.ofSeq
+let wordCount (phrase: string) = 
+    Regex.Matches(phrase.ToLowerInvariant(), @"\w+('\w+)*") 
+    |> Seq.cast<Match> 
+    |> Seq.groupBy (fun m -> m.Value)
+    |> Seq.map (fun (word, occurrences) -> word, occurrences |> Seq.length)                     
+    |> Map.ofSeq

--- a/exercises/word-count/WordCountTests.fs
+++ b/exercises/word-count/WordCountTests.fs
@@ -3,120 +3,118 @@
 open NUnit.Framework
 open Phrase
 
-type WordCountTests() =
-    
-    [<Test>]
-    member tests.Count_one_word() =
-        let phrase = Phrase("word");
-        let counts = Map.ofSeq [("word", 1)]
+[<Test>]
+let ``Count one word`` () =
+    let phrase = "word"
+    let counts = Map.ofSeq [("word", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Count_one_of_each() =
-        let phrase = Phrase("one of each");
-        let counts = Map.ofSeq [("one",  1);
-                                ("of",   1);
-                                ("each", 1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Count one of each`` () =
+    let phrase = "one of each"
+    let counts = Map.ofSeq [("one",  1);
+                            ("of",   1);
+                            ("each", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Count_multiple_occurrences() =
-        let phrase = Phrase("one fish two fish red fish blue fish");
-        let counts = Map.ofSeq [("one",  1);
-                                ("fish", 4);
-                                ("two",  1);
-                                ("red",  1);
-                                ("blue", 1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Count multiple occurrences`` () =
+    let phrase = "one fish two fish red fish blue fish"
+    let counts = Map.ofSeq [("one",  1);
+                            ("fish", 4);
+                            ("two",  1);
+                            ("red",  1);
+                            ("blue", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Count_everything_just_once() =
-        let phrase = Phrase("all the kings horses and all the kings men");
-        let counts = Map.ofSeq [("all",    2);
-                                ("the",    2);
-                                ("kings",  2);
-                                ("horses", 1);
-                                ("and",    1);
-                                ("men",    1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Count everything just once`` () =
+    let phrase = "all the kings horses and all the kings men"
+    let counts = Map.ofSeq [("all",    2);
+                            ("the",    2);
+                            ("kings",  2);
+                            ("horses", 1);
+                            ("and",    1);
+                            ("men",    1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Ignore_punctuation() =
-        let phrase = Phrase("car : carpet as java : javascript!!&@$%^&");
-        let counts = Map.ofSeq [("car",        1);
-                                ("carpet",     1);
-                                ("as",         1);
-                                ("java",       1);
-                                ("javascript", 1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Ignore punctuation`` () =
+    let phrase = "car : carpet as java : javascript!!&@$%^&"
+    let counts = Map.ofSeq [("car",        1);
+                            ("carpet",     1);
+                            ("as",         1);
+                            ("java",       1);
+                            ("javascript", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Handles_cramped_list() =
-        let phrase = Phrase("one,two,three");
-        let counts = Map.ofSeq [("one",   1);
-                                ("two",   1);
-                                ("three", 1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Handles cramped list`` () =
+    let phrase = "one,two,three"
+    let counts = Map.ofSeq [("one",   1);
+                            ("two",   1);
+                            ("three", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Include_numbers() =
-        let phrase = Phrase("testing, 1, 2 testing");
-        let counts = Map.ofSeq [("testing", 2);
-                                ("1",       1);
-                                ("2",       1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Include numbers`` () =
+    let phrase = "testing, 1, 2 testing"
+    let counts = Map.ofSeq [("testing", 2);
+                            ("1",       1);
+                            ("2",       1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.Normalize_case() =
-        let phrase = Phrase("go Go GO");
-        let counts = Map.ofSeq [("go", 3)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Normalize case`` () =
+    let phrase = "go Go GO"
+    let counts = Map.ofSeq [("go", 3)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.With_apostrophes() =
-        let phrase = Phrase("First: don't laugh. Then: don't cry.");
-        let counts = Map.ofSeq [("first", 1);
-                                ("don't", 2);
-                                ("laugh", 1);
-                                ("then",  1);
-                                ("cry",   1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``With apostrophes`` () =
+    let phrase = "First: don't laugh. Then: don't cry."
+    let counts = Map.ofSeq [("first", 1);
+                            ("don't", 2);
+                            ("laugh", 1);
+                            ("then",  1);
+                            ("cry",   1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.With_free_standing_apostrophes() =
-        let phrase = Phrase("go ' Go '' GO");
-        let counts = Map.ofSeq [("go", 3)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``With free standing apostrophes`` () =
+    let phrase = "go ' Go '' GO"
+    let counts = Map.ofSeq [("go", 3)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))
 
-    [<Test>]
-    [<Ignore("Remove to run test")>]
-    member tests.With_apostrophes_as_quotes() =
-        let phrase = Phrase("She said, 'let's meet at twelve o'clock'");
-        let counts = Map.ofSeq [("she", 1);
-                                ("said", 1);
-                                ("let's", 1);
-                                ("meet", 1);
-                                ("at", 1);
-                                ("twelve", 1);
-                                ("o'clock", 1)]
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``With apostrophes as quotes`` () =
+    let phrase = "She said, 'let's meet at twelve o'clock'"
+    let counts = Map.ofSeq [("she", 1);
+                            ("said", 1);
+                            ("let's", 1);
+                            ("meet", 1);
+                            ("at", 1);
+                            ("twelve", 1);
+                            ("o'clock", 1)]
 
-        Assert.That(phrase.wordCount(), Is.EqualTo(counts))
+    Assert.That(wordCount phrase, Is.EqualTo(counts))

--- a/exercises/wordy/WordyTest.fs
+++ b/exercises/wordy/WordyTest.fs
@@ -4,80 +4,80 @@ open NUnit.Framework
 open WordProblem
 
 [<Test>]
-let ``Can parse and solve addition problems``() =
-    Assert.That(solve("What is 1 plus 1?"), Is.EqualTo(Some 2))
+let ``Can parse and solve addition problems`` () =
+    Assert.That(solve "What is 1 plus 1?", Is.EqualTo(Some 2))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add double digit numbers``() =
-    Assert.That(solve("What is 53 plus 2?"), Is.EqualTo(Some 55))
+let ``Can add double digit numbers`` () =
+    Assert.That(solve "What is 53 plus 2?", Is.EqualTo(Some 55))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add negative numbers``() =
-    Assert.That(solve("What is -1 plus -10?"), Is.EqualTo(Some -11))
+let ``Can add negative numbers`` () =
+    Assert.That(solve "What is -1 plus -10?", Is.EqualTo(Some -11))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add large numbers``() =
-    Assert.That(solve("What is 123 plus 45678?"), Is.EqualTo(Some 45801))
+let ``Can add large numbers`` () =
+    Assert.That(solve "What is 123 plus 45678?", Is.EqualTo(Some 45801))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can parse and solve subtraction problems``() =
-    Assert.That(solve("What is 4 minus -12"), Is.EqualTo(Some 16))
+let ``Can parse and solve subtraction problems`` () =
+    Assert.That(solve "What is 4 minus -12", Is.EqualTo(Some 16))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can parse and solve multiplication problems``() =
-    Assert.That(solve("What is -3 multiplied by 25?"), Is.EqualTo(Some -75))
+let ``Can parse and solve multiplication problems`` () =
+    Assert.That(solve "What is -3 multiplied by 25?", Is.EqualTo(Some -75))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can parse and solve division problems``() =
-    Assert.That(solve("What is 33 divided by -3?"), Is.EqualTo(Some -11))
+let ``Can parse and solve division problems`` () =
+    Assert.That(solve "What is 33 divided by -3?", Is.EqualTo(Some -11))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add twice``() =
-    Assert.That(solve("What is 1 plus 1 plus 1?"), Is.EqualTo(Some 3))
+let ``Can add twice`` () =
+    Assert.That(solve "What is 1 plus 1 plus 1?", Is.EqualTo(Some 3))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add then subtract``() =
-    Assert.That(solve("What is 1 plus 5 minus -2?"), Is.EqualTo(Some 8))
+let ``Can add then subtract`` () =
+    Assert.That(solve "What is 1 plus 5 minus -2?", Is.EqualTo(Some 8))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can subtract twice``() =
-    Assert.That(solve("What is 20 minus 4 minus 13?"), Is.EqualTo(Some 3))
+let ``Can subtract twice`` () =
+    Assert.That(solve "What is 20 minus 4 minus 13?", Is.EqualTo(Some 3))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can subtract then add``() =
-    Assert.That(solve("What is 17 minus 6 plus 3?"), Is.EqualTo(Some 14))
+let ``Can subtract then add`` () =
+    Assert.That(solve "What is 17 minus 6 plus 3?", Is.EqualTo(Some 14))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can multiply twice``() =
-    Assert.That(solve("What is 2 multiplied by -2 multiplied by 3?"), Is.EqualTo(Some -12))
+let ``Can multiply twice`` () =
+    Assert.That(solve "What is 2 multiplied by -2 multiplied by 3?", Is.EqualTo(Some -12))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can add then multiply``() =
-    Assert.That(solve("What is -3 plus 7 multiplied by -2?"), Is.EqualTo(Some -8))
+let ``Can add then multiply`` () =
+    Assert.That(solve "What is -3 plus 7 multiplied by -2?", Is.EqualTo(Some -8))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Can divide twice``() =
-    Assert.That(solve("What is -12 divided by 2 divided by -3?"), Is.EqualTo(Some 2))
+let ``Can divide twice`` () =
+    Assert.That(solve "What is -12 divided by 2 divided by -3?", Is.EqualTo(Some 2))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Cubed is too advanced``() =
-    Assert.That(solve("What is 53 cubed?"), Is.EqualTo(None))
+let ``Cubed is too advanced`` () =
+    Assert.That(solve "What is 53 cubed?", Is.EqualTo(None))
     
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Irrelevent problems are not valid``() =
-    Assert.That(solve("Who is the president of the United States?"), Is.EqualTo(None))
+let ``Irrelevent problems are not valid`` () =
+    Assert.That(solve "Who is the president of the United States?", Is.EqualTo(None))


### PR DESCRIPTION
This PR converts the existing exercises to use idiomatic F#. In practice this means that classes are avoided where possible. As an example, this is the old `bob` exercise:

```fsharp
type Bob(statement: string) =
    let isEmpty = String.IsNullOrWhiteSpace input
    let isYell = Seq.exists Char.IsLetter input && input = input.ToUpperInvariant()
    let isQuestion = input.EndsWith "?"

    member this.hey() =
        match input with 
        | _ when isEmpty -> "Fine. Be that way!"
        | _ when isYell -> "Whoa, chill out!"
        | _ when isQuestion -> "Sure."
```

And this is the new exercise:

```fsharp
let hey(input: string) = 
    let isEmpty = String.IsNullOrWhiteSpace input
    let isYell = Seq.exists Char.IsLetter input && input = input.ToUpperInvariant()
    let isQuestion = input.EndsWith "?"

    match input with 
        | _ when isEmpty -> "Fine. Be that way!"
        | _ when isYell -> "Whoa, chill out!"
        | _ when isQuestion -> "Sure."
        | _ -> "Whatever."
```

The same process is applied to the tests, where test classes are converted to plain functions:

```fsharp
[<TestFixture>]
type BinaryTests() =
    
    [<TestCase("1", Result = 1)>]
    [<TestCase("10", Result = 2, Ignore = true)>]
    [<TestCase("11", Result = 3, Ignore = true)>]
    [<TestCase("100", Result = 4, Ignore = true)>]
    [<TestCase("1001", Result = 9, Ignore = true)>]
    [<TestCase("11010", Result = 26, Ignore = true)>]
    [<TestCase("10001101000", Result = 1128, Ignore = true)>]
    member tests.Binary_converts_to_decimal(input) =
        Binary(input).toDecimal()

    [<TestCase("carrot", Ignore = true)>]
    [<TestCase("2", Ignore = true)>]
    [<TestCase("5", Ignore = true)>]
    [<TestCase("9", Ignore = true)>]
    [<TestCase("134678", Ignore = true)>]
    [<TestCase("abc10z", Ignore = true)>]
    member tests.Invalid_binary_is_decimal_0(input) =
        Assert.That(Binary(input).toDecimal(), Is.EqualTo(0))
```

becomes:

```fsharp
[<TestCase("1", ExpectedResult = 1)>]
[<TestCase("10", ExpectedResult = 2, Ignore = "Remove to run test case")>]
[<TestCase("11", ExpectedResult = 3, Ignore = "Remove to run test case")>]
[<TestCase("100", ExpectedResult = 4, Ignore = "Remove to run test case")>]
[<TestCase("1001", ExpectedResult = 9, Ignore = "Remove to run test case")>]
[<TestCase("11010", ExpectedResult = 26, Ignore = "Remove to run test case")>]
[<TestCase("10001101000", ExpectedResult = 1128, Ignore = "Remove to run test case")>]
let ``Binary converts to decimal`` (input: string) =
    toDecimal input

[<TestCase("carrot", Ignore = "Remove to run test case")>]
[<TestCase("2", Ignore = "Remove to run test case")>]
[<TestCase("5", Ignore = "Remove to run test case")>]
[<TestCase("9", Ignore = "Remove to run test case")>]
[<TestCase("134678", Ignore = "Remove to run test case")>]
[<TestCase("abc10z", Ignore = "Remove to run test case")>]
let ``Invalid binary is decimal 0`` (input: string) =
    Assert.That(toDecimal input, Is.EqualTo(0))
```

This example also shows that all tests now use the triple-backticks feature that allows the test function  names to include characters like spaces.

I've also tried to use the default building blocks (lists and tuples) as much as possible, in favor of using types. 

Finally, I've tried to write the tests such that the user is free to implement it however he/she likes.

fyi @kytrinyx 