### PR TITLE
Add transpose exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -98,7 +98,8 @@
     "markdown",
     "all-your-base",
     "rectangles",
-    "sgf-parsing"
+    "sgf-parsing",
+    "transpose"
   ],
   "deprecated": [    
     "binary",

--- a/exercises/transpose/Example.fs
+++ b/exercises/transpose/Example.fs
@@ -1,0 +1,6 @@
+﻿module Transpose
+
+let rec transpose = function
+    | (_::_)::_ as M -> List.map List.head M :: transpose (List.map List.tail M)
+    | _ -> []
+

--- a/exercises/transpose/TransposeTest.fs
+++ b/exercises/transpose/TransposeTest.fs
@@ -1,0 +1,82 @@
+﻿module TransposeTest
+
+open NUnit.Framework
+
+open Transpose
+
+[<Test>]
+let ``Empty list`` () = 
+    let input = []
+    let expected = []
+    Assert.That(transpose input, Is.EqualTo(expected))
+
+[<Test>]
+[<Ignore("Remove to run test")>]  
+let ``One row`` () = 
+    let input = 
+        [ 
+            [2; 3; 5; 7; 11; 13] 
+        ]
+    let expected = 
+        [ 
+            [2];
+            [3];
+            [5];
+            [7];
+            [11];
+            [13] 
+        ]
+    Assert.That(transpose input, Is.EqualTo(expected))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]  
+let ``One column`` () = 
+    let input = 
+        [ 
+            [2];
+            [3];
+            [5];
+            [7];
+            [11];
+            [13] 
+        ]
+    let expected = 
+        [ 
+            [2; 3; 5; 7; 11; 13] 
+        ]
+    Assert.That(transpose input, Is.EqualTo(expected))
+
+[<Test>]
+[<Ignore("Remove to run test")>]  
+let ``Square`` () = 
+    let input = 
+        [ 
+            [ 2;  3;  5]; 
+            [ 7; 11; 13]; 
+            [19; 21; 23] 
+        ]
+    let expected = 
+        [ 
+            [2;  7; 19];
+            [3; 11; 21];
+            [5; 13; 23] 
+        ]
+    Assert.That(transpose input, Is.EqualTo(expected))
+
+[<Test>]
+[<Ignore("Remove to run test")>]  
+let ``Rectangle`` () = 
+    let input = 
+        [ 
+            [ 2;  3]; 
+            [ 5;  7]; 
+            [11; 13]; 
+            [19; 21]; 
+            [23; 29] 
+        ]
+    let expected = 
+        [ 
+            [2; 5; 11; 19; 23];
+            [3; 7; 13; 21; 29] 
+        ]
+    Assert.That(transpose input, Is.EqualTo(expected))


### PR DESCRIPTION
This PR adds the [transpose](https://github.com/exercism/x-common/blob/master/transpose.md) exercise. 

@kytrinyx There is currently no test data specified for the transpose exercise, so this PR is my initial attempt. Do we also want to include some error checking? For example if there are rows with a different number of columns and vice versa? I'd be happy to convert submit a PR to x-common to add test data to the transpose exercise, if we can agree upon which test data we want.