### PR TITLE
Update PangramTest.fs with another edge case

### DIFF
--- a/exercises/pangram/PangramTest.fs
+++ b/exercises/pangram/PangramTest.fs
@@ -56,3 +56,10 @@ let ``Pangram with mixed case and punctuation`` () =
 let ``Pangram with non ascii characters`` () =
     let input = "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich."
     Assert.That(isPangram input, Is.True)
+
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Panagram in alphabet other than ASCII`` () =
+    let input = "Широкая электрификация южных губерний даст мощный толчок подъёму сельского хозяйства."
+    Assert.That(isPangram input, Is.False)
+    


### PR DESCRIPTION
Looking a solutions at (http://exercism.io/tracks/fsharp/exercises/pangram) I found one that would pass all the unit test and yet be invalid since it does not check whether symbols belong to alphabet 'a'..'z'