### PR TITLE
Normalize test module names

### DIFF
--- a/exercises/accumulate/AccumulateTest.fs
+++ b/exercises/accumulate/AccumulateTest.fs
@@ -1,4 +1,4 @@
-﻿module AccumulateTests
+﻿module AccumulateTest
 
 open System
 open NUnit.Framework

--- a/exercises/acronym/AcronymTest.fs
+++ b/exercises/acronym/AcronymTest.fs
@@ -1,4 +1,4 @@
-module AcronymTests
+module AcronymTest
 
 open NUnit.Framework
 open Acronym

--- a/exercises/allergies/AllergiesTest.fs
+++ b/exercises/allergies/AllergiesTest.fs
@@ -1,4 +1,4 @@
-﻿module AllergiesTests
+﻿module AllergiesTest
 
 open System
 open NUnit.Framework

--- a/exercises/anagram/AnagramTest.fs
+++ b/exercises/anagram/AnagramTest.fs
@@ -1,4 +1,4 @@
-module AnagramTests
+module AnagramTest
 
 open System
 open NUnit.Framework

--- a/exercises/atbash-cipher/AtbashTest.fs
+++ b/exercises/atbash-cipher/AtbashTest.fs
@@ -1,4 +1,4 @@
-module AtbashTests
+module AtbashTest
 
 open NUnit.Framework
 open Atbash

--- a/exercises/bob/BobTest.fs
+++ b/exercises/bob/BobTest.fs
@@ -1,4 +1,4 @@
-﻿module BobTests
+﻿module BobTest
 
 open NUnit.Framework
 open Bob

--- a/exercises/clock/ClockTest.fs
+++ b/exercises/clock/ClockTest.fs
@@ -1,4 +1,4 @@
-module ClockTests
+module ClockTest
 
 open System
 open NUnit.Framework

--- a/exercises/crypto-square/CryptoSquareTest.fs
+++ b/exercises/crypto-square/CryptoSquareTest.fs
@@ -1,4 +1,4 @@
-module CryptoSquareTests
+module CryptoSquareTest
 
 open NUnit.Framework
 open CryptoSquare

--- a/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTest.fs
@@ -1,4 +1,4 @@
-﻿module DifferenceOfSquaresTests
+﻿module DifferenceOfSquaresTest
 
 open NUnit.Framework
 open DifferenceOfSquares

--- a/exercises/etl/ETLTest.fs
+++ b/exercises/etl/ETLTest.fs
@@ -1,4 +1,4 @@
-﻿module ETLTests
+﻿module ETLTest
 
 open NUnit.Framework
 open ETL

--- a/exercises/grade-school/GradeSchoolTest.fs
+++ b/exercises/grade-school/GradeSchoolTest.fs
@@ -1,4 +1,4 @@
-module GradeSchoolTests
+module GradeSchoolTest
 
 open NUnit.Framework
 open School

--- a/exercises/hamming/HammingTest.fs
+++ b/exercises/hamming/HammingTest.fs
@@ -1,4 +1,4 @@
-﻿module HammingTests
+﻿module HammingTest
 
 open NUnit.Framework
 open Hamming

--- a/exercises/leap/LeapTest.fs
+++ b/exercises/leap/LeapTest.fs
@@ -1,4 +1,4 @@
-﻿module LeapYearTests
+﻿module LeapYearTest
 
 open NUnit.Framework
 open LeapYear

--- a/exercises/linked-list/LinkedListTest.fs
+++ b/exercises/linked-list/LinkedListTest.fs
@@ -1,4 +1,4 @@
-module DequeTests
+module DequeTest
 
 open NUnit.Framework
 open Deque

--- a/exercises/luhn/LuhnTest.fs
+++ b/exercises/luhn/LuhnTest.fs
@@ -1,4 +1,4 @@
-module LuhnTests
+module LuhnTest
 
 open NUnit.Framework
 open Luhn

--- a/exercises/pig-latin/PigLatinTest.fs
+++ b/exercises/pig-latin/PigLatinTest.fs
@@ -1,4 +1,4 @@
-﻿module PigLatinTests
+﻿module PigLatinTest
 
 open NUnit.Framework
 open PigLatin

--- a/exercises/raindrops/RaindropsTest.fs
+++ b/exercises/raindrops/RaindropsTest.fs
@@ -1,4 +1,4 @@
-module RaindropsTests
+module RaindropsTest
     
 open NUnit.Framework
 open Raindrops

--- a/exercises/rna-transcription/RNATranscriptionTest.fs
+++ b/exercises/rna-transcription/RNATranscriptionTest.fs
@@ -1,4 +1,4 @@
-﻿module RNATranscriptionTests
+﻿module RNATranscriptionTest
 
 open NUnit.Framework
 

--- a/exercises/roman-numerals/RomanNumeralTest.fs
+++ b/exercises/roman-numerals/RomanNumeralTest.fs
@@ -1,4 +1,4 @@
-﻿module RomanNumeralTests
+﻿module RomanNumeralTest
 
 open NUnit.Framework
 open RomanNumeral

--- a/exercises/saddle-points/SaddlePointTest.fs
+++ b/exercises/saddle-points/SaddlePointTest.fs
@@ -1,4 +1,4 @@
-﻿module SaddlePointTests
+﻿module SaddlePointTest
 
 open NUnit.Framework
 

--- a/exercises/scrabble-score/ScrabbleScoreTest.fs
+++ b/exercises/scrabble-score/ScrabbleScoreTest.fs
@@ -1,4 +1,4 @@
-module ScrabbleScoreTests
+module ScrabbleScoreTest
 
 open NUnit.Framework
 open Scrabble

--- a/exercises/series/SeriesTest.fs
+++ b/exercises/series/SeriesTest.fs
@@ -1,4 +1,4 @@
-module SeriesTests
+module SeriesTest
 
 open System
 open NUnit.Framework

--- a/exercises/space-age/SpaceAgeTest.fs
+++ b/exercises/space-age/SpaceAgeTest.fs
@@ -1,4 +1,4 @@
-﻿module SpaceAgeTests
+﻿module SpaceAgeTest
 
 open NUnit.Framework
 open SpaceAge

--- a/exercises/strain/StrainTest.fs
+++ b/exercises/strain/StrainTest.fs
@@ -1,4 +1,4 @@
-module StrainTests
+module StrainTest
 
 open System.Collections.Specialized
 open NUnit.Framework

--- a/exercises/word-count/WordCountTest.fs
+++ b/exercises/word-count/WordCountTest.fs
@@ -1,4 +1,4 @@
-﻿module WordCountTests
+﻿module WordCountTest
 
 open NUnit.Framework
 open Phrase


### PR DESCRIPTION
After the normalization of the test files as *Test.fs there were some module names that weren't conforming to the *Test format.