### PR TITLE
New test for grep exercise

### DIFF
--- a/exercises/grep/GrepTest.fs
+++ b/exercises/grep/GrepTest.fs
@@ -88,6 +88,16 @@ let ``One file, several matches, print line numbers flag`` () =
     Assert.That(grep pattern flags files, Is.EqualTo(expected))
 
 [<Test>]
+let ``One file, several matches, match entire lines flag`` () =
+    let pattern = "may"
+    let flags = "-x"
+    let files = [midsummerNightFileName]
+
+    let expected = ""
+
+    Assert.That(grep pattern flags files, Is.EqualTo(expected))
+
+[<Test>]
 [<Ignore("Remove to run test")>]
 let ``One file, one match, print file names flag`` () =
     let pattern = "Forbidden"


### PR DESCRIPTION
Check that "match entire lines" flag is correctly implemented.

As an alternative to this PR, you could wait until the https://github.com/exercism/x-common/pull/369 PR is merged, then re-create the `grep` exercise tests from that data. But I figured since I'd already written the F# version of the test, it costs almost nothing to do a PR in case that's faster than re-creating the tests from the `grep.json` file in x-common.