### PR TITLE
Remove Ignore attributes on tests for refactoring exercises

### DIFF
--- a/exercises/ledger/LedgerTest.fs
+++ b/exercises/ledger/LedgerTest.fs
@@ -9,66 +9,62 @@ let ``Empty ledger`` () =
     let currency = "USD"
     let locale = "en-US"
     let entries = []
-    let expected = 
+    let expected =
         "Date       | Description               | Change       "
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``One entry`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-01" "Buy present" -1000
         ]
-    let expected = 
+    let expected =
         "Date       | Description               | Change       \n" +
         "01/01/2015 | Buy present               |      ($10.00)"
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Credit and debit`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-02" "Get present"  1000;
             mkEntry "2015-01-01" "Buy present" -1000
         ]
-    let expected = 
+    let expected =
         "Date       | Description               | Change       \n" +
         "01/01/2015 | Buy present               |      ($10.00)\n" +
         "01/02/2015 | Get present               |       $10.00 "
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-  
-[<Test>] 
-[<Ignore("Remove to run test")>] 
+ 
+[<Test>]
 let ``Multiple entries on same date ordered by description`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-01" "Buy present" -1000;
             mkEntry "2015-01-01" "Get present"  1000
         ]
-    let expected = 
+    let expected =
         "Date       | Description               | Change       \n" +
         "01/01/2015 | Buy present               |      ($10.00)\n" +
-        "01/01/2015 | Get present               |       $10.00 " 
+        "01/01/2015 | Get present               |       $10.00 "
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-    
+   
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Final order tie breaker is change`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-01" "Something" 0;
             mkEntry "2015-01-01" "Something" -1;
@@ -81,13 +77,12 @@ let ``Final order tie breaker is change`` () =
         "01/01/2015 | Something                 |        $0.01 "
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-   
-[<Test>] 
-[<Ignore("Remove to run test")>]
+  
+[<Test>]
 let ``Overlong descriptions`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-01" "Freude schoner Gotterfunken" -123456
         ]
@@ -96,13 +91,12 @@ let ``Overlong descriptions`` () =
         "01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)"
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-   
-[<Test>] 
-[<Ignore("Remove to run test")>]
+  
+[<Test>]
 let ``Euros`` () =
     let currency = "EUR"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-01-01" "Buy present" -1000
         ]
@@ -111,13 +105,12 @@ let ``Euros`` () =
         "01/01/2015 | Buy present               |      (€10.00)"
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-    
+   
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Dutch locale`` () =
     let currency = "USD"
     let locale = "nl-NL"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-03-12" "Buy present" 123456
         ]
@@ -126,32 +119,30 @@ let ``Dutch locale`` () =
         "12-03-2015 | Buy present               |   $ 1.234,56 "
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-  
-[<Test>]  
-[<Ignore("Remove to run test")>]
+ 
+[<Test>]
 let ``Dutch negative number with 3 digits before decimal point`` () =
     let currency = "USD"
     let locale = "nl-NL"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-03-12" "Buy present" -12345
         ]
-    let expected = 
+    let expected =
         "Datum      | Omschrijving              | Verandering  \n" +
         "12-03-2015 | Buy present               |     $ -123,45"
 
     Assert.That(formatLedger currency locale entries, Is.EqualTo(expected))
-    
+   
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``American negative number with 3 digits before decimal point`` () =
     let currency = "USD"
     let locale = "en-US"
-    let entries = 
+    let entries =
         [
             mkEntry "2015-03-12" "Buy present" -12345
         ]
-    let expected = 
+    let expected =
         "Date       | Description               | Change       \n" +
         "03/12/2015 | Buy present               |     ($123.45)"
 

--- a/exercises/markdown/MarkdownTest.fs
+++ b/exercises/markdown/MarkdownTest.fs
@@ -11,56 +11,48 @@ let ``Parses normal text as a paragraph`` () =
     Assert.That(parse input, Is.EqualTo(expected))
     
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Parsing italics`` () =
     let input = "_This will be italic_"
     let expected = "<p><i>This will be italic</i></p>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Parsing bold text`` () =
     let input = "__This will be bold__"
     let expected = "<p><em>This will be bold</em></p>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Mixed normal, italics and bold text`` () =
     let input = "This will _be_ __mixed__"
     let expected = "<p>This will <i>be</i> <em>mixed</em></p>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``With h1 header level`` () =
     let input = "# This will be an h1"
     let expected = "<h1>This will be an h1</h1>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``With h2 header level`` () =
     let input = "## This will be an h2"
     let expected = "<h2>This will be an h2</h2>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``With h6 header level`` () =
     let input = "###### This will be an h6"
     let expected = "<h6>This will be an h6</h6>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Unordered lists`` () =
     let input = "* Item 1\n* Item 2"
     let expected = "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``With a little bit of everything`` () =
     let input = "# Header!\n* __Bold Item__\n* _Italic Item_"
     let expected = "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"

--- a/exercises/tree-building/TreeBuildingTest.fs
+++ b/exercises/tree-building/TreeBuildingTest.fs
@@ -14,7 +14,6 @@ let ``One node`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Three nodes in order`` () =
     let input = 
         [
@@ -26,7 +25,6 @@ let ``Three nodes in order`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Three nodes in reverse order`` () =
     let input = 
         [
@@ -38,7 +36,6 @@ let ``Three nodes in reverse order`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``More than two children`` () =
     let input = 
         [
@@ -51,7 +48,6 @@ let ``More than two children`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Binary tree`` () =
     let input = 
         [
@@ -68,7 +64,6 @@ let ``Binary tree`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Unbalanced tree`` () =
     let input =
         [
@@ -85,13 +80,11 @@ let ``Unbalanced tree`` () =
     Assert.That(buildTree input, Is.EqualTo(expected))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Empty input`` () =
     let input = []
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Root node has parent`` () =
     let input = 
         [ { RecordId = 0; ParentId =  1 };
@@ -99,13 +92,11 @@ let ``Root node has parent`` () =
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``No root node`` () =
     let input = [ { RecordId = 1; ParentId = -1 } ]
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
     
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Non-continuous`` () =
     let input = 
         [
@@ -117,7 +108,6 @@ let ``Non-continuous`` () =
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Cycle directly`` () =
     let input = 
         [
@@ -132,7 +122,6 @@ let ``Cycle directly`` () =
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Cycle indirectly`` () =
     let input = 
         [ 
@@ -147,7 +136,6 @@ let ``Cycle indirectly`` () =
     Assert.That((fun () -> buildTree input |> ignore), Throws.Exception)
 
 [<Test>]
-[<Ignore("Remove to run test")>]
 let ``Higher id parent of lower id`` () =
     let input = 
         [ 


### PR DESCRIPTION
The refactoring exercises already have all of the tests passing so there's no need to progressively un-ignore them like when you're building a solution to an exercise.