### PR TITLE
Add hints for grains test (#234)

### DIFF
--- a/exercises/grains/HINTS.md
+++ b/exercises/grains/HINTS.md
@@ -1,0 +1,3 @@
+## Hints
+For this exercise the following F# feature comes in handy:
+- [BigInt](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/numerics.biginteger-structure-%5Bfsharp%5D)


### PR DESCRIPTION
This is to address #234 (adding hints for exercises)

@ErikSchierboom This was inspired by the work you did on the Scala track [here](https://github.com/exercism/xscala/pull/222/files). Is this what you had in mind? If so, then I'll try to add some more as well.