### PR TITLE
Mac Documentation Improvements

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,10 +5,9 @@ Install [Xamarin Studio](http://xamarin.com/download).
 While Xamarin is most known for creating iOS and Android applications, it's still a perfect IDE to create F# console
 or library projects which is all that's needed for Exercism.
 
-Once installed and running, click on new solution and you'll find the library project to select. Don't forget to click the
-lanugage drop down to select F# since it defaults to C#.
+Once installed and running, you can validate the installation by starting Xamarin creating a new solution. On the left hand side select .NET, and on the right hand side select Library. Library should have a little button-shapped drop down box to it's right that says C#. Click it and you'll see you can also choose F#.
 
-![Xamarin New Project](http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp.jpg)
+<img alt="Xamarin New Projct" src="http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp.jpg" style="width:100%; height: 100%;">
 
 #### Linux
 The [F# Foundation](http://fsharp.org/) has detailed instructions on different options to install F# on [Linux](http://fsharp.org/use/linux/).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -28,7 +28,7 @@ Now you can have fun learning F# and run your code against the tests!
 ### Mac
 Xamarin Studio also ships with NUnit. From the new project dialog, just select an NUnit class library.
 
-![Xamarin NUnit](http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp-nunit.jpg)
+<img alt="Xamarin NUnit" src=" http://x.exercism.io/v3/tracks/fsharp/docs/img/xamarin-fsharp-nunit.jpg" style="height: 100%; width: 100%;" />
 
 From here you can write NUnit tests right away. To run the tests open the `Unit Tests` pad within
 Xamarin (View -> Pads -> Unit Tests).


### PR DESCRIPTION
The Mac docs seemed to assume you'd read the Windows docs first, as they didn't make it clear what you were supposed to do with the solutions you were creating. So I made few small changes.

- Clarify in the installation step that you are only verifying your fsharp installation.
- Explain what you are supposed to do with your NUnit solution once you create it.  

Both of these were unclear to me as a mac user. I also went ahead and cleaned up the images for mac, which are huge on the current website. 