### PR TITLE
Change linked-lists tests and example to use mutation.

### DIFF
--- a/exercises/linked-list/Example.fs
+++ b/exercises/linked-list/Example.fs
@@ -1,36 +1,43 @@
 module LinkedList
 
 type Element<'a> = { value: 'a; mutable prev: Element<'a> option; mutable next: Element<'a> option }
-type LinkedList<'a> = { first: Element<'a> option; last: Element<'a> option }
+type LinkedList<'a> = { mutable first: Element<'a> option; mutable last: Element<'a> option }
 
-let mkLinkedList = { first = None; last = None }
+let mkLinkedList () = { first = None; last = None }
 
-let addToEmpty newValue linkedList = 
+let addToEmpty newValue linkedList =
     let newElement = { value = newValue; prev = None; next = None }
-    { linkedList with first = Some newElement; last = Some newElement }
+    linkedList.first <- Some newElement
+    linkedList.last <- Some newElement
 
 let pop linkedList =
     match linkedList.last with
     | None -> failwith "Cannot pop from empty list"
-    | Some(x) -> x.value, { linkedList with last = x.prev }
+    | Some oldLast ->
+        linkedList.last <- oldLast.prev
+        linkedList.last |> Option.iter (fun el -> el.next <- None)
+        oldLast.value
 
 let shift linkedList =
     match linkedList.first with
     | None -> failwith "Cannot shift from empty list"
-    | Some(x) -> x.value, { linkedList with first = x.next }
-        
-let push newValue linkedList = 
+    | Some oldFirst ->
+        linkedList.first <- oldFirst.next
+        linkedList.first |> Option.iter (fun el -> el.prev <- None)
+        oldFirst.value
+
+let push newValue linkedList =
     match linkedList.last with
     | None -> addToEmpty newValue linkedList
-    | Some(x) ->         
-        let last = Some { value = newValue; prev = linkedList.last; next = x.next }
-        x.next <- last            
-        { linkedList with last = last }
+    | Some oldLast ->
+        let newLast = Some { value = newValue; prev = linkedList.last; next = None }
+        oldLast.next <- newLast
+        linkedList.last <- newLast
 
-let unshift newValue linkedList =        
+let unshift newValue linkedList =
     match linkedList.first with
     | None -> addToEmpty newValue linkedList
-    | Some(x) ->     
-        let first = Some { value = newValue; prev = x.prev; next = linkedList.first }
-        x.prev <- first
-        { linkedList with first = first }
+    | Some oldFirst ->
+        let newFirst = Some { value = newValue; prev = None; next = linkedList.first }
+        oldFirst.prev <- newFirst
+        linkedList.first <- newFirst

--- a/exercises/linked-list/HINTS.md
+++ b/exercises/linked-list/HINTS.md
@@ -1,0 +1,14 @@
+## Hints
+
+A [doubly linked list](https://en.wikipedia.org/wiki/Doubly_linked_list) is a mutable data structure. As F# is a functional-first language, immutability is generally preferred, but there are language features that allow the use of mutation where it is required.
+
+* The `mutable` keyword can be placed before `let` bindings and [record](https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/records) fields, allowing you to assign new values to them.
+
+* [Class](https://fsharpforfunandprofit.com/posts/classes) properties can be made mutable by specifying a property setter with the `set` keyword.
+
+Mutable bindings must be re-assigned with `<-`
+
+```fsharp
+let mutable x = "initial value"
+x <- "new value"
+```

--- a/exercises/linked-list/LinkedListTest.fs
+++ b/exercises/linked-list/LinkedListTest.fs
@@ -5,117 +5,110 @@ open LinkedList
 
 [<Test>]
 let ``Push and pop are first in last out order`` () =
-    let linkedList = 
-        mkLinkedList
-        |> push 10
-        |> push 20
+    let linkedList = mkLinkedList ()
+    linkedList |> push 10
+    linkedList |> push 20
 
-    let (val', linkedList') = pop linkedList
-    let (val'', _) = pop linkedList'
+    let val1 = pop linkedList
+    let val2 = pop linkedList
 
-    Assert.That(val', Is.EqualTo(20))
-    Assert.That(val'', Is.EqualTo(10))
+    Assert.That(val1, Is.EqualTo(20))
+    Assert.That(val2, Is.EqualTo(10))
 
-[<Test>]  
-[<Ignore("Remove to run test")>]  
+[<Test>]
+[<Ignore("Remove to run test")>]
 let ``Push and shift are first in first out order`` () =
-    let linkedList = 
-        mkLinkedList
-        |> push 10
-        |> push 20
+    let linkedList = mkLinkedList ()
+    linkedList |> push 10
+    linkedList |> push 20
 
-    let (val', linkedList') = shift linkedList
-    let (val'', _) = shift linkedList'
+    let val1 = shift linkedList
+    let val2 = shift linkedList
 
-    Assert.That(val', Is.EqualTo(10))
-    Assert.That(val'', Is.EqualTo(20))
+    Assert.That(val1, Is.EqualTo(10))
+    Assert.That(val2, Is.EqualTo(20))
 
-[<Test>] 
-[<Ignore("Remove to run test")>]  
+[<Test>]
+[<Ignore("Remove to run test")>]
 let ``Unshift and shift are last in first out order`` () =
-    let linkedList = 
-        mkLinkedList
-        |> unshift 10
-        |> unshift 20
+    let linkedList = mkLinkedList ()
+    linkedList |> unshift 10
+    linkedList |> unshift 20
 
-    let (val', linkedList') = shift linkedList
-    let (val'', _) = shift linkedList'
+    let val1 = shift linkedList
+    let val2 = shift linkedList
 
-    Assert.That(val', Is.EqualTo(20))
-    Assert.That(val'', Is.EqualTo(10))
+    Assert.That(val1, Is.EqualTo(20))
+    Assert.That(val2, Is.EqualTo(10))
 
-[<Test>]    
+[<Test>]
 [<Ignore("Remove to run test")>]
 let ``Unshift and pop are last in last out order`` () =
-    let linkedList = 
-        mkLinkedList
-        |> unshift 10
-        |> unshift 20
+    let linkedList = mkLinkedList ()
+    linkedList |> unshift 10
+    linkedList |> unshift 20
 
-    let (val', linkedList') = pop linkedList
-    let (val'', _) = pop linkedList'
+    let val1 = pop linkedList
+    let val2 = pop linkedList
 
-    Assert.That(val', Is.EqualTo(10))
-    Assert.That(val'', Is.EqualTo(20))
+    Assert.That(val1, Is.EqualTo(10))
+    Assert.That(val2, Is.EqualTo(20))
 
-[<Test>]    
+[<Test>]
 [<Ignore("Remove to run test")>]
 let ``Push and pop can handle multiple values`` () =
-    let linkedList = 
-        mkLinkedList
-        |> push 10
-        |> push 20
-        |> push 30
+    let linkedList = mkLinkedList ()
+    linkedList |> push 10
+    linkedList |> push 20
+    linkedList |> push 30
 
-    let (val', linkedList') = pop linkedList
-    let (val'', linkedList'') = pop linkedList'
-    let (val''', _) = pop linkedList''
+    let val1 = pop linkedList
+    let val2 = pop linkedList
+    let val3 = pop linkedList
 
-    Assert.That(val', Is.EqualTo(30))
-    Assert.That(val'', Is.EqualTo(20))
-    Assert.That(val''', Is.EqualTo(10))
+    Assert.That(val1, Is.EqualTo(30))
+    Assert.That(val2, Is.EqualTo(20))
+    Assert.That(val3, Is.EqualTo(10))
 
-[<Test>]    
+[<Test>]
 [<Ignore("Remove to run test")>]
 let ``Unshift and shift can handle multiple values`` () =
-    let linkedList = 
-        mkLinkedList
-        |> unshift 10
-        |> unshift 20
-        |> unshift 30
+    let linkedList = mkLinkedList ()
+    linkedList |> unshift 10
+    linkedList |> unshift 20
+    linkedList |> unshift 30
 
-    let (val', linkedList') = shift linkedList
-    let (val'', linkedList'') = shift linkedList'
-    let (val''', _) = shift linkedList''
+    let val1 = shift linkedList
+    let val2 = shift linkedList
+    let val3 = shift linkedList
 
-    Assert.That(val', Is.EqualTo(30))
-    Assert.That(val'', Is.EqualTo(20))
-    Assert.That(val''', Is.EqualTo(10))
+    Assert.That(val1, Is.EqualTo(30))
+    Assert.That(val2, Is.EqualTo(20))
+    Assert.That(val3, Is.EqualTo(10))
 
-[<Test>]    
+[<Test>]
 [<Ignore("Remove to run test")>]
 let ``All methods of manipulating the linkedList can be used together`` () =
-    let linkedList = 
-        mkLinkedList
-        |> push 10
-        |> push 20
+    let linkedList = mkLinkedList ()
+    linkedList |> push 10
+    linkedList |> push 20
 
-    let (val', linkedList') = pop linkedList
+    let val1 = pop linkedList
 
-    Assert.That(val', Is.EqualTo(20))
+    Assert.That(val1, Is.EqualTo(20))
 
-    let linkedList'' = push 30 linkedList'
-    let (val''', linkedList''') = shift linkedList''
+    linkedList |> push 30
+    let val2 = shift linkedList
 
-    Assert.That(val''', Is.EqualTo(10))
+    Assert.That(val2, Is.EqualTo(10))
 
-    let linkedList'''' = unshift 40 linkedList'''
-    let linkedList''''' = push 50 linkedList''''
+    linkedList |> unshift 40
+    linkedList |> push 50
 
-    let (val'''''', linkedList'''''') = shift linkedList'''''
-    let (val''''''', linkedList''''''') = pop linkedList''''''
-    let (val'''''''', _) = shift linkedList'''''''
-        
-    Assert.That(val'''''', Is.EqualTo(40))
-    Assert.That(val''''''', Is.EqualTo(50))
-    Assert.That(val'''''''', Is.EqualTo(30))
+    let val3 = shift linkedList
+    let val4 = pop linkedList
+    let val5 = shift linkedList
+
+    Assert.That(val3, Is.EqualTo(40))
+    Assert.That(val4, Is.EqualTo(50))
+    Assert.That(val5, Is.EqualTo(30))


### PR DESCRIPTION
For #240.

I also fixed an error in `pop` and `shift` where next/prev elements weren't being set to `None` and the list was keeping references to items that had been removed. The tests do not check for this.