### PR TITLE
Prevent permission issues in grep exercise

### DIFF
--- a/exercises/grep/GrepTest.fs
+++ b/exercises/grep/GrepTest.fs
@@ -44,6 +44,7 @@ That Shepherd, who first taught the chosen Seed
 
 [<OneTimeSetUp>]
 let setUp () =
+    Directory.SetCurrentDirectory(Path.GetTempPath());
     File.WriteAllText(iliadFileName, iliadContents)
     File.WriteAllText(midsummerNightFileName, midsummerNightContents)
     File.WriteAllText(paradiseLostFileName, paradiseLostContents)


### PR DESCRIPTION
To prevent permission issues, we write the file in the user's temp directory.