### PR TITLE
Make Markdown exercise consistent by never expecting `<p>` inside `<li>`

### DIFF
--- a/exercises/markdown/Example.fs
+++ b/exercises/markdown/Example.fs
@@ -1,6 +1,5 @@
 ﻿module Markdown
 
-open System
 open System.Text.RegularExpressions
 
 let openingTag tag = sprintf "<%s>" tag
@@ -27,15 +26,11 @@ let parseDelimited delimiter tag (markdown: string) =
 let parseBold   = parseDelimited "__" boldTag
 let parseItalic = parseDelimited "_"  italicTag
 
-let correctLine list (markdown: string) = 
-    if list && (startsWithTag boldTag markdown || startsWithTag italicTag markdown) then markdown
-    else wrapInTag paragraphTag markdown
-
 let parseText list (markdown: string) =
     markdown
     |> parseBold
     |> parseItalic
-    |> correctLine list
+    |> if list then id else wrapInTag paragraphTag
 
 let (|Header|_|) (list: bool) (markdown: string) = 
     let headerNumber = 

--- a/exercises/markdown/Markdown.fs
+++ b/exercises/markdown/Markdown.fs
@@ -49,14 +49,8 @@ let rec parse (markdown: string) =
                else
                    __pos <- -1
                    
-           if not notusep then
-               html <- html + "<p>"
-
            html <- html + line 
 
-           if not notusep then
-               html <- html + "</p>"
-           
            html <- html + "</li>"          
 
        elif lines.[i].[0] = '#' then

--- a/exercises/markdown/MarkdownTest.fs
+++ b/exercises/markdown/MarkdownTest.fs
@@ -49,7 +49,7 @@ let ``With h6 header level`` () =
 [<Test>]
 let ``Unordered lists`` () =
     let input = "* Item 1\n* Item 2"
-    let expected = "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>"
+    let expected = "<ul><li>Item 1</li><li>Item 2</li></ul>"
     Assert.That(parse input, Is.EqualTo(expected))
 
 [<Test>]


### PR DESCRIPTION
The tests here expect to see a `<p>` inside `<li>` only when the text isn't contained in some other tag such as `<em>`. See these snippets from two different tests:

```fsharp
    let expected = "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>"
    ...
    let expected = "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i>
```

Neither GitHub markdown nor [CommonMark](http://spec.commonmark.org/dingus/) behave like this so I couldn't see a reason to expect it.

I've removed the expected `<p>` in the tests and updated both implementations. I intentionally left behind the unused variable `notusep` in the "bad" implementation.