### PR TITLE
Add circle CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ packages/
 tools/
 .fake/
 .paket/paket.exe
+paket-files
 TestResult.xml
+junit-results.xml

--- a/build.fsx
+++ b/build.fsx
@@ -6,11 +6,12 @@ open Fake.Testing.NUnit3
 
 // Directories
 let buildDir  = "./build/"
-let sourceDir  = "./exercises/"
+let sourceDir = "./exercises/"
 
 // Files
 let solutionFile = buildDir @@ "/exercises.fsproj"
 let compiledOutput = buildDir @@ "xfsharp.dll"
+let nunitToJunitTransformFile = "./paket-files" @@ "nunit" @@ "nunit-transforms" @@ "nunit3-junit" @@ "nunit3-junit.xslt"
 
 // Targets
 Target "Clean" (fun _ ->
@@ -42,6 +43,11 @@ Target "Test" (fun _ ->
         |> NUnit3 (fun p -> { p with 
                                 ShadowCopy = false
                                 ToolPath = "nunit3-console.exe" })
+    else if getEnvironmentVarAsBool "CIRCLECI" then
+        [compiledOutput]
+        |> NUnit3 (fun p -> { p with 
+                                ShadowCopy = false
+                                ResultSpecs = [sprintf "junit-results.xml;transform=%s" nunitToJunitTransformFile] })
     else
         [compiledOutput]
         |> NUnit3 (fun p -> { p with ShadowCopy = false })

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  environment:
+    TERM: xterm-256color
+dependencies:
+  pre:
+    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    - echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+    - sudo apt-get update
+    - sudo apt-get install mono-complete fsharp
+test:
+  override:
+    - ./build.sh
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - sed -i '1 s/^\xef\xbb\xbf//' .*/junit-results.xml
+    - find . -type f -regex ".*/junit-results.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,3 +4,4 @@ nuget FParsec
 nuget FSharp.Core
 nuget NUnit
 nuget NUnit.ConsoleRunner
+github nunit/nunit-transforms nunit3-junit/nunit3-junit.xslt

--- a/paket.lock
+++ b/paket.lock
@@ -5,3 +5,6 @@ NUGET
     FSharp.Core (4.0.0.1)
     NUnit (3.5)
     NUnit.ConsoleRunner (3.5)
+GITHUB
+  remote: nunit/nunit-transforms
+    nunit3-junit/nunit3-junit.xslt (2a7c74198375b4b280ff3e79033c3d44e3083850)


### PR DESCRIPTION
This PR adds support for the CircleCI build server. Unfortunately, I cannot give CircleCI the permissions on the exercism/xfsharp repository, as I am not the owner. This PR should thus not be merged, which is why I marked it as WIP.

@kytrinyx, once you are back from your well-deserved break, would you mind granting the CircleCI repository access to  the xfsharp (xcsharp) repositories? You can find CircleCI here: https://circleci.com