### PR TITLE
Add concurrency test to bank-account exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,13 +66,6 @@
       ]
     },
     {
-      "slug": "bank-account",
-      "difficulty": 2,
-      "topics": [
-        "Optional values"
-      ]
-    },
-    {
       "slug": "grains",
       "difficulty": 2,
       "topics": [
@@ -555,6 +548,14 @@
         "Strings",
         "Algorithms",
         "Transforming"
+      ]
+    },
+    {
+      "slug": "bank-account",
+      "difficulty": 5,
+      "topics": [
+        "Optional values",
+        "Concurrency"
       ]
     },
     {

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -44,7 +44,8 @@ let ``Balance can increment or decrement`` () =
     Assert.That(subtractedBalance, Is.EqualTo(Some -5.0))
 
 [<Test>]
-[<Ignore("Remove to run test")>]let ``Account can be closed`` () =
+[<Ignore("Remove to run test")>]
+let ``Account can be closed`` () =
     let account = 
         mkBankAccount()
         |> openAccount
@@ -55,7 +56,6 @@ let ``Balance can increment or decrement`` () =
 [<Test>]
 [<Ignore("Remove to run test")>]
 let ``Account can be updated from multiple threads`` () =
-
     let account = 
         mkBankAccount()
         |> openAccount
@@ -68,9 +68,9 @@ let ``Account can be updated from multiple threads`` () =
         }
 
     updateAccountAsync
-    |> List.replicate 20
+    |> List.replicate 1000
     |> Async.Parallel 
     |> Async.RunSynchronously
     |> ignore
 
-    Assert.That(account |> getBalance, Is.EqualTo(Some 20.0))
+    Assert.That(account |> getBalance, Is.EqualTo(Some 1000.0))

--- a/exercises/bank-account/BankAccountTest.fs
+++ b/exercises/bank-account/BankAccountTest.fs
@@ -12,11 +12,13 @@ let ``Returns empty balance after opening`` () =
 [<Test>]
 [<Ignore("Remove to run test")>]
 let ``Check basic balance`` () =
-    let account1 = mkBankAccount() |> openAccount
-    let openingBalance = account1 |> getBalance 
+    let account = mkBankAccount() |> openAccount
+    let openingBalance = account |> getBalance 
 
-    let account2 = account1 |> updateBalance 10.0
-    let updatedBalance = account2 |> getBalance
+    let updatedBalance = 
+        account
+        |> updateBalance 10.0 
+        |> getBalance
 
     Assert.That(openingBalance, Is.EqualTo(Some 0.0))
     Assert.That(updatedBalance, Is.EqualTo(Some 10.0))
@@ -24,25 +26,51 @@ let ``Check basic balance`` () =
 [<Test>]
 [<Ignore("Remove to run test")>]
 let ``Balance can increment or decrement`` () =    
-    let account1 = mkBankAccount() |> openAccount
-    let openingBalance = account1 |> getBalance 
+    let account = mkBankAccount() |> openAccount
+    let openingBalance = account |> getBalance 
 
-    let account2 = account1 |> updateBalance 10.0
-    let addedBalance = account2 |> getBalance
+    let addedBalance = 
+        account 
+        |> updateBalance 10.0
+        |> getBalance
 
-    let account3 = account2 |> updateBalance -15.0
-    let subtractedBalance = account3 |> getBalance
+    let subtractedBalance = 
+        account 
+        |> updateBalance -15.0
+        |> getBalance
 
     Assert.That(openingBalance, Is.EqualTo(Some 0.0))
     Assert.That(addedBalance, Is.EqualTo(Some 10.0))
     Assert.That(subtractedBalance, Is.EqualTo(Some -5.0))
 
 [<Test>]
-[<Ignore("Remove to run test")>]
-let ``Account can be closed`` () =
+[<Ignore("Remove to run test")>]let ``Account can be closed`` () =
     let account = 
         mkBankAccount()
         |> openAccount
         |> closeAccount
 
     Assert.That(account |> getBalance, Is.EqualTo(None))
+    
+[<Test>]
+[<Ignore("Remove to run test")>]
+let ``Account can be updated from multiple threads`` () =
+
+    let account = 
+        mkBankAccount()
+        |> openAccount
+
+    let updateAccountAsync =        
+        async {                             
+            account 
+            |> updateBalance 1.0
+            |> ignore
+        }
+
+    updateAccountAsync
+    |> List.replicate 20
+    |> Async.Parallel 
+    |> Async.RunSynchronously
+    |> ignore
+
+    Assert.That(account |> getBalance, Is.EqualTo(Some 20.0))

--- a/exercises/bank-account/Example.fs
+++ b/exercises/bank-account/Example.fs
@@ -20,10 +20,7 @@ let closeAccount (account: BankAccount) =
         account
     )
 
-let getBalance (account: BankAccount) = 
-    lock account.Lock (fun () ->
-        account.Balance
-    )
+let getBalance (account: BankAccount) = account.Balance
 
 let updateBalance change (account: BankAccount) = 
     lock account.Lock (fun () ->

--- a/exercises/bank-account/Example.fs
+++ b/exercises/bank-account/Example.fs
@@ -1,24 +1,32 @@
 ﻿module BankAccount
 
-type BankAccount = 
-    | Open of float
-    | Closed
+open System
 
-let mkBankAccount() = Closed
+type BankAccount() = 
+    member val Lock = new Object()
+    member val Balance: float option = None with get,set
 
-let openAccount =
-    function
-    | Open x -> Open x
-    | Closed -> Open 0.0
+let mkBankAccount() = BankAccount()
 
-let closeAccount x = Closed
+let openAccount (account: BankAccount) = 
+    lock account.Lock (fun () ->
+        account.Balance <- Some 0.0
+        account
+    )
 
-let getBalance =
-    function
-    | Open x -> Some x
-    | Closed -> None
+let closeAccount (account: BankAccount) = 
+    lock account.Lock (fun () ->
+        account.Balance <- None    
+        account
+    )
 
-let updateBalance change =
-    function
-    | Open x -> Open (x + change)
-    | Closed -> Closed
+let getBalance (account: BankAccount) = 
+    lock account.Lock (fun () ->
+        account.Balance
+    )
+
+let updateBalance change (account: BankAccount) = 
+    lock account.Lock (fun () ->
+        account.Balance <- Option.map ((+) change) account.Balance    
+        account
+    )


### PR DESCRIPTION
In #260, we discussed the merits of converting the bank-account exercise to one that checks for concurrency issues. This PR adds this test and updates the implementation.