### PR TITLE
Use correct ignore string in Luhn test

### DIFF
--- a/exercises/luhn/LuhnTest.fs
+++ b/exercises/luhn/LuhnTest.fs
@@ -4,10 +4,10 @@ open NUnit.Framework
 open Luhn
   
 [<TestCase("1", ExpectedResult = false)>] // single digit strings can not be valid
-[<TestCase("0", ExpectedResult = false, Ignore = "Remove to run test")>] // a single zero is invalid
-[<TestCase("046 454 286", ExpectedResult = true, Ignore = "Remove to run test")>] // valid Canadian SIN
-[<TestCase("046 454 287", ExpectedResult = false, Ignore = "Remove to run test")>] // invalid Canadian SIN
-[<TestCase("8273 1232 7352 0569", ExpectedResult = false, Ignore = "Remove to run test")>] // invalid credit card
-[<TestCase("827a 1232 7352 0569", ExpectedResult = false, Ignore = "Remove to run test")>] // strings that contain non-digits are not valid
+[<TestCase("0", ExpectedResult = false, Ignore = "Remove to run test case")>] // a single zero is invalid
+[<TestCase("046 454 286", ExpectedResult = true, Ignore = "Remove to run test case")>] // valid Canadian SIN
+[<TestCase("046 454 287", ExpectedResult = false, Ignore = "Remove to run test case")>] // invalid Canadian SIN
+[<TestCase("8273 1232 7352 0569", ExpectedResult = false, Ignore = "Remove to run test case")>] // invalid credit card
+[<TestCase("827a 1232 7352 0569", ExpectedResult = false, Ignore = "Remove to run test case")>] // strings that contain non-digits are not valid
 let ``Validate checksum`` number =
     valid number


### PR DESCRIPTION
When using TestCase, the Ignore string must be exactly equal to "Remove to run test case". Otherwise, the CI servers don't run the test.