### PR TITLE
Refactored tree building tests. Fixes #250

### DIFF
--- a/exercises/tree-building/Example.fs
+++ b/exercises/tree-building/Example.fs
@@ -5,6 +5,12 @@ type Tree =
     | Branch of int * Tree list
     | Leaf of int
 
+let recordId = function Branch (id, _) | Leaf id -> id
+
+let isBranch = function Branch _ -> true  | Leaf _ -> false
+
+let children = function Branch (_, children') -> children' | Leaf _ -> []
+
 let rootNodeRecordId = 0
 
 let addOrAppend key value map =

--- a/exercises/tree-building/TreeBuilding.fs
+++ b/exercises/tree-building/TreeBuilding.fs
@@ -5,6 +5,21 @@ type Tree =
     | Branch of int * Tree list
     | Leaf of int
 
+let recordId t = 
+    match t with
+    | Branch (id, c) -> id
+    | Leaf id -> id
+
+let isBranch t = 
+    match t with
+    | Branch (id, c) -> true
+    | Leaf id -> false
+
+let children t = 
+    match t with
+    | Branch (id, c) -> c
+    | Leaf id -> []
+
 let buildTree records = 
     let records' = List.sortBy (fun x -> x.RecordId) records
 

--- a/exercises/tree-building/TreeBuildingTest.fs
+++ b/exercises/tree-building/TreeBuildingTest.fs
@@ -10,8 +10,12 @@ let ``One node`` () =
         [ 
             { RecordId = 0; ParentId = 0 } 
         ]
-    let expected = Leaf 0
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+
+    Assert.That(isBranch tree, Is.False)
+    Assert.That(recordId tree, Is.EqualTo(0))    
+    Assert.That(children tree, Is.EqualTo([]))
 
 [<Test>]
 let ``Three nodes in order`` () =
@@ -21,8 +25,18 @@ let ``Three nodes in order`` () =
             { RecordId = 1; ParentId = 0 };
             { RecordId = 2; ParentId = 0 };
         ]
-    let expected = Branch (0, [Leaf 1; Leaf 2])
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+
+    Assert.That(isBranch tree, Is.True)
+    Assert.That(recordId tree, Is.EqualTo(0))
+    Assert.That(children tree |> List.length, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> recordId, Is.EqualTo(1))
+
+    Assert.That(children tree |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> recordId, Is.EqualTo(2))
 
 [<Test>]
 let ``Three nodes in reverse order`` () =
@@ -32,8 +46,18 @@ let ``Three nodes in reverse order`` () =
             { RecordId = 1; ParentId = 0 };
             { RecordId = 0; ParentId = 0 };
         ]
-    let expected = Branch (0, [Leaf 1; Leaf 2])
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+    
+    Assert.That(isBranch tree, Is.True)
+    Assert.That(recordId tree, Is.EqualTo(0))
+    Assert.That(children tree |> List.length, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> recordId, Is.EqualTo(1))
+
+    Assert.That(children tree |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> recordId, Is.EqualTo(2))
 
 [<Test>]
 let ``More than two children`` () =
@@ -44,8 +68,21 @@ let ``More than two children`` () =
             { RecordId = 1; ParentId = 0 };
             { RecordId = 0; ParentId = 0 };
         ]
-    let expected = Branch (0, [Leaf 1; Leaf 2; Leaf 3])
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+    
+    Assert.That(isBranch tree, Is.True)
+    Assert.That(recordId tree, Is.EqualTo(0))
+    Assert.That(children tree |> List.length, Is.EqualTo(3))
+
+    Assert.That(children tree |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> recordId, Is.EqualTo(1))
+
+    Assert.That(children tree |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> recordId, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 2 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 2 |> recordId, Is.EqualTo(3))
 
 [<Test>]
 let ``Binary tree`` () =
@@ -59,9 +96,32 @@ let ``Binary tree`` () =
             { RecordId = 0; ParentId = 0 };
             { RecordId = 6; ParentId = 2 }
         ]
-    let expected = Branch (0, [ Branch (1, [Leaf 4; Leaf 5]); 
-                                Branch (2, [Leaf 3; Leaf 6]) ])
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+        
+    Assert.That(isBranch tree, Is.True)
+    Assert.That(recordId tree, Is.EqualTo(0))
+    Assert.That(children tree |> List.length, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 0 |> isBranch, Is.True)
+    Assert.That(children tree |> List.item 0 |> recordId, Is.EqualTo(1))    
+    Assert.That(children tree |> List.item 0 |> children |> List.length, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 0 |> children |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> children |> List.item 0 |> recordId, Is.EqualTo(4))
+
+    Assert.That(children tree |> List.item 0 |> children |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> children |> List.item 1 |> recordId, Is.EqualTo(5))
+    
+    Assert.That(children tree |> List.item 1 |> isBranch, Is.True)
+    Assert.That(children tree |> List.item 1 |> recordId, Is.EqualTo(2))    
+    Assert.That(children tree |> List.item 1 |> children |> List.length, Is.EqualTo(2))
+    
+    Assert.That(children tree |> List.item 1 |> children |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> children |> List.item 0 |> recordId, Is.EqualTo(3))
+
+    Assert.That(children tree |> List.item 1 |> children |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> children |> List.item 1 |> recordId, Is.EqualTo(6))
 
 [<Test>]
 let ``Unbalanced tree`` () =
@@ -75,9 +135,32 @@ let ``Unbalanced tree`` () =
             { RecordId = 0; ParentId = 0 };
             { RecordId = 6; ParentId = 2 }
         ]
-    let expected = Branch (0, [ Branch (1, [Leaf 4]); 
-                                Branch (2, [Leaf 3; Leaf 5; Leaf 6]) ])
-    Assert.That(buildTree input, Is.EqualTo(expected))
+
+    let tree = buildTree input
+        
+    Assert.That(isBranch tree, Is.True)
+    Assert.That(recordId tree, Is.EqualTo(0))
+    Assert.That(children tree |> List.length, Is.EqualTo(2))
+
+    Assert.That(children tree |> List.item 0 |> isBranch, Is.True)
+    Assert.That(children tree |> List.item 0 |> recordId, Is.EqualTo(1))    
+    Assert.That(children tree |> List.item 0 |> children |> List.length, Is.EqualTo(1))
+
+    Assert.That(children tree |> List.item 0 |> children |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 0 |> children |> List.item 0 |> recordId, Is.EqualTo(4))
+    
+    Assert.That(children tree |> List.item 1 |> isBranch, Is.True)
+    Assert.That(children tree |> List.item 1 |> recordId, Is.EqualTo(2))
+    Assert.That(children tree |> List.item 1 |> children |> List.length, Is.EqualTo(3))
+    
+    Assert.That(children tree |> List.item 1 |> children |> List.item 0 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> children |> List.item 0 |> recordId, Is.EqualTo(3))
+
+    Assert.That(children tree |> List.item 1 |> children |> List.item 1 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> children |> List.item 1 |> recordId, Is.EqualTo(5))
+
+    Assert.That(children tree |> List.item 1 |> children |> List.item 2 |> isBranch, Is.False)
+    Assert.That(children tree |> List.item 1 |> children |> List.item 2 |> recordId, Is.EqualTo(6))
 
 [<Test>]
 let ``Empty input`` () =


### PR DESCRIPTION
This PR makes the tree building tests not force any specific implementation upon the user. For the discussion, see #250.