### PR TITLE
Remove test from triangle. Closes #282

### DIFF
--- a/exercises/triangle/TriangleTest.fs
+++ b/exercises/triangle/TriangleTest.fs
@@ -70,10 +70,5 @@ let ``Triangles violating triangle inequality are illegal`` () =
 
 [<Test>]
 [<Ignore("Remove to run test")>]
-let ``Triangles violating triangle inequality are illegal 2`` () =
-    Assert.That((fun () -> kind 2m 4m 2m |> ignore), Throws.InvalidOperationException)
-
-[<Test>]
-[<Ignore("Remove to run test")>]
 let ``Triangles violating triangle inequality are illegal 3`` () =
     Assert.That((fun () -> kind 7m 3m 2m |> ignore), Throws.InvalidOperationException)


### PR DESCRIPTION
As discussed in #282, the 2 4 2 triangle test is marked as incorrectly marked as invalid. The correct solution according to the [canonical data](https://github.com/exercism/x-common/blob/master/exercises/triangle/canonical-data.json) is to remove this test:
> we have decided NOT to test triangles where all side lengths are positive but a + b = c., e.g: (2, 4, 2, Isosceles), (1, 3, 4, Scalene).",

This PR removes said test.