### PR TITLE
Simple Cipher: add missing Ignore attribute

### DIFF
--- a/exercises/simple-cipher/SimpleCipherTest.fs
+++ b/exercises/simple-cipher/SimpleCipherTest.fs
@@ -62,6 +62,7 @@ let ``Cipher is reversible given key`` () =
     Assert.That(encode key plainText |> decode key, Is.EqualTo(plainText))
     
 [<Test>]
+[<Ignore("Remove to run test")>]
 let ``Cipher can double shift encode`` () =
     let plainText = "iamapandabear"
     Assert.That(encode plainText plainText, Is.EqualTo("qayaeaagaciai"))


### PR DESCRIPTION
The `Ignore` attribute was missing from the test case `Cipher can double shift encode` so I added it.