### PR TITLE
Simple cipher: fix comment grammar

### DIFF
--- a/exercises/simple-cipher/SimpleCipherTest.fs
+++ b/exercises/simple-cipher/SimpleCipherTest.fs
@@ -25,7 +25,7 @@ let ``Encode random uses randomly generated key`` () =
     let keys = List.init 100 (fun _ -> encodeRandom plainText |> fst)
     Assert.That(keys |> List.distinct, Is.EqualTo(keys))
 
-// Here we take advantage of the fact that plaintext of "aaa..." doesn't output
+// Here we take advantage of the fact that plaintext of "aaa..." outputs
 // the key. This is a critical problem with shift ciphers, some characters
 // will always output the key verbatim.
 [<Test>]


### PR DESCRIPTION
The original comment said: "Here we take advantage of the fact that plaintext of "aaa..." doesn't output the key." If I understand correctly, this is the opposite of what was meant, that is, "Here we take advantage of the fact that plaintext of "aaa..." outputs the key."