### PR TITLE
Modify test cases using foldr - issue 314

### DIFF
--- a/exercises/list-ops/Example.fs
+++ b/exercises/list-ops/Example.fs
@@ -5,7 +5,7 @@ let rec foldl folder state list =
     | [] -> state
     | x::xs -> foldl folder (folder state x) xs
 
-let rec foldr folder state list =
+let rec foldr folder list state =
     list
     |> List.rev
     |> foldl (fun acc item -> folder item acc) state
@@ -14,10 +14,10 @@ let length list = foldl (fun acc _ -> acc + 1) 0 list
 
 let reverse list = foldl (fun acc item -> item :: acc) [] list
 
-let map f list = foldr (fun item acc -> f item :: acc) [] list
+let map f list = foldr (fun item acc -> f item :: acc) list []
 
-let filter f list = foldr (fun item acc -> if f item then item :: acc else acc) [] list
+let filter f list = foldr (fun item acc -> if f item then item :: acc else acc) list []
 
-let append xs ys = foldr (fun item acc -> item :: acc) ys xs
+let append xs ys = foldr (fun item acc -> item :: acc) xs ys
 
-let concat xs = foldr append [] xs
+let concat xs = foldr append xs []

--- a/exercises/list-ops/ListOpsTest.fs
+++ b/exercises/list-ops/ListOpsTest.fs
@@ -80,12 +80,12 @@ let ``foldl is not just foldr . flip`` () =
 [<Test>]
 [<Ignore("Remove to run test")>]
 let ``foldr as id`` () =
-    Assert.That(foldr (fun item acc -> item :: acc) [] [1 .. big] = bigList, Is.True)
+    Assert.That(foldr (fun item acc -> item :: acc) [1 .. big] [] = bigList, Is.True)
 
 [<Test>]
 [<Ignore("Remove to run test")>]
 let ``foldr as append`` () =
-    Assert.That(foldr (fun item acc -> item :: acc) [100 .. big] [1 .. 99] = bigList, Is.True)
+    Assert.That(foldr (fun item acc -> item :: acc) [1 .. 99] [100 .. big] = bigList, Is.True)
 
 [<Test>]
 [<Ignore("Remove to run test")>]


### PR DESCRIPTION
modified the test cases that use foldr so that the syntax reflects the same order of the accumulator and foldable list that is used in List.foldBack